### PR TITLE
fix(metrics): align success-status policy with documented behavior

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -122,12 +122,35 @@ vex --target localhost --port 8443 --insecure
 
 ## Output Configuration
 
+### `--success-status <PATTERN>`
+
+Define which HTTP status codes count as successful requests.
+
+- Default: `2xx` (HTTP 200-299 only)
+- Pattern syntax supports class (2xx, 3xx, 4xx, 5xx) or specific codes (comma-separated)
+
+Examples:
+
+```bash
+# Default: only 2xx counts as success
+vex --target example.com
+
+# Count both 2xx and 3xx as success
+vex --target example.com --success-status 2xx,3xx
+
+# Count specific status codes as success
+vex --target example.com --success-status 200,201,204,301,302
+```
+
+This affects the "Successful/Failed requests" counts in the output.
+
 ### `--verbose`
 
 Enable verbose output.
 
 - Default: Disabled
 - Prints response headers for each request (may reduce throughput)
+- Only captures response body when verbose is enabled
 - Useful for debugging
 
 ```bash

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -21,8 +21,13 @@ Successful requests: 995
 Failed requests: 5
 ```
 
-- Success: HTTP requests with 2xx status codes (200-299)
-- Failure: Any other outcome (3xx, 4xx, 5xx, network errors, timeouts)
+- **Success**: HTTP requests matching the `--success-status` criteria (default: 2xx only)
+- **Failure**: Any other outcome (non-matching status codes, network errors, timeouts)
+
+By default, only HTTP 2xx status codes (200-299) are counted as successful. You can customize this with `--success-status`:
+- `--success-status 2xx` (default): Only 2xx status codes
+- `--success-status 2xx,3xx`: Both 2xx and 3xx status codes
+- `--success-status 200,201,301`: Specific status codes
 
 ### Completion Reason
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,27 +7,7 @@ pub mod client;
 pub mod utils;
 
 use client::h3_client::ErrorStats;
-
-/// Helper function to compute percentile from sorted values
-fn percentile(sorted_values: &[f64], p: f64) -> f64 {
-    if sorted_values.is_empty() {
-        return 0.0;
-    }
-    if sorted_values.len() == 1 {
-        return sorted_values[0];
-    }
-
-    let idx = (p / 100.0) * (sorted_values.len() - 1) as f64;
-    let lower = idx.floor() as usize;
-    let upper = idx.ceil() as usize;
-    let weight = idx - idx.floor();
-
-    if lower == upper {
-        sorted_values[lower]
-    } else {
-        sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
-    }
-}
+use utils::{percentile, is_success_status};
 
 #[derive(Parser)]
 #[command(version, about = "HTTP/3 load testing tool")]
@@ -61,6 +41,9 @@ struct Cli {
 
     #[arg(long, default_value = "false")]
     verbose: bool,
+
+    #[arg(long, default_value = "2xx", help = "HTTP status codes to consider as success (e.g., '2xx', '2xx,3xx', or specific codes '200,201,301')")]
+    success_status: String,
 }
 
 #[tokio::main]
@@ -116,6 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let path = cli.path.clone();
         let insecure = cli.insecure;
         let verbose = cli.verbose;
+        let success_status = cli.success_status.clone();
         let requests_per_worker = quotient + if worker_id < remainder { 1 } else { 0 };
         let deadline = Arc::clone(&deadline);
 
@@ -145,8 +129,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // Track status code
                         *status_codes.entry(result.status_code).or_insert(0) += 1;
 
-                        // Classify as success/fail based on status code (2xx is success/ redirect are not failure)
-                        if (result.status_code >= 200 && result.status_code < 300) || (result.status_code == 301 || result.status_code == 302)  {
+                        // Classify as success/fail based on success_status pattern
+                        if is_success_status(result.status_code, &success_status) {
                             success += 1;
                         } else {
                             fail += 1;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -82,6 +82,75 @@ pub fn resolve_target(target: &str, port: u16) -> Result<SocketAddr, Box<dyn std
         .ok_or_else(|| format!("Could not resolve host: {}", target).into())
 }
 
+/// Compute percentile from sorted values using linear interpolation
+///
+/// # Arguments
+/// * `sorted_values` - Values sorted in ascending order
+/// * `p` - Percentile value (0-100)
+///
+/// # Examples
+/// * `percentile(&[1.0, 2.0, 3.0], 50.0)` → 2.0 (median)
+/// * `percentile(&[1.0, 2.0, 3.0, 4.0, 5.0], 95.0)` → 4.8
+pub fn percentile(sorted_values: &[f64], p: f64) -> f64 {
+    if sorted_values.is_empty() {
+        return 0.0;
+    }
+    if sorted_values.len() == 1 {
+        return sorted_values[0];
+    }
+
+    let idx = (p / 100.0) * (sorted_values.len() - 1) as f64;
+    let lower = idx.floor() as usize;
+    let upper = idx.ceil() as usize;
+    let weight = idx - idx.floor();
+
+    if lower == upper {
+        sorted_values[lower]
+    } else {
+        sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+    }
+}
+
+/// Parse success status pattern and check if a status code is considered success
+///
+/// # Arguments
+/// * `status_code` - HTTP status code (e.g., 200, 301, 404)
+/// * `success_pattern` - Pattern string (e.g., "2xx", "2xx,3xx", "200,201,301")
+///
+/// # Supported patterns
+/// - Class patterns: `2xx`, `3xx`, `4xx`, `5xx`
+/// - Specific codes: comma-separated list (e.g., `200,201,301`)
+/// - Mixed: `2xx,3xx,500`
+///
+/// # Examples
+/// * `is_success_status(200, "2xx")` → true
+/// * `is_success_status(301, "2xx")` → false
+/// * `is_success_status(301, "2xx,3xx")` → true
+/// * `is_success_status(301, "200,201,301")` → true
+pub fn is_success_status(status_code: u16, success_pattern: &str) -> bool {
+    for part in success_pattern.split(',') {
+        let part = part.trim();
+        if part == "2xx" && status_code >= 200 && status_code < 300 {
+            return true;
+        }
+        if part == "3xx" && status_code >= 300 && status_code < 400 {
+            return true;
+        }
+        if part == "4xx" && status_code >= 400 && status_code < 500 {
+            return true;
+        }
+        if part == "5xx" && status_code >= 500 && status_code < 600 {
+            return true;
+        }
+        if let Ok(code) = part.parse::<u16>() {
+            if status_code == code {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**Closes:** #13

## Solution

Made success status classification configurable while keeping the default aligned with documentation:

1. **Added `--success-status` CLI option** with sensible defaults
   - Default: `2xx` (matches documentation)
   - Supports flexible patterns: `2xx`, `3xx`, `4xx`, `5xx`, or specific codes
   - Examples: `--success-status 2xx,3xx` or `--success-status 200,201,301`

2. **Moved utility functions to proper location**
   - `percentile()` → `utils.rs`
   - `is_success_status()` → `utils.rs`
   - Clean separation of concerns

3. **Updated documentation**
   - Clarified default behavior (2xx only)
   - Added CLI reference with usage examples
   - Explained configuration options in METRICS.md
   
## Usage Examples

```bash
# Default: only 2xx counts as success
vex --target example.com

# Count both 2xx and 3xx as success (e.g., for redirect-heavy services)
vex --target example.com --success-status 2xx,3xx

# Count specific status codes as success
vex --target example.com --success-status 200,201,204,301,302
```
