### PR TITLE
feat: add per-worker concurrent in-flight requests via Futures Unordered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +666,7 @@ name = "vex"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "futures",
  "http",
  "quiche",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ quiche = "0.24.6"
 http = "1.3.1"
 rand = "0.8"
 clap = { version = "4.0", features = ["derive"] }
+futures = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Instant, Duration};
 use std::collections::HashMap;
+use futures::stream::{FuturesUnordered, StreamExt};
 
 pub mod client;
 pub mod utils;
@@ -38,6 +40,9 @@ struct Cli {
 
     #[arg(long, default_value = "2xx", help = "HTTP status codes to consider as success (e.g., '2xx', '2xx,3xx', or specific codes '200,201,301')")]
     success_status: String,
+
+    #[arg(short = 'c', long, default_value = "1", help = "Number of concurrent in-flight requests per worker")]
+    concurrency: usize,
 }
 
 #[tokio::main]
@@ -51,11 +56,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let host = cli.target.clone();
 
+    if cli.concurrency == 0 {
+        eprintln!("concurrency must be at least 1");
+        std::process::exit(1);
+    }
+
     println!("Starting HTTP/3 load test:");
     println!("  Target: {}:{}", cli.target, cli.port);
     println!("  Host: {}", host);
     println!("  Path: {}", cli.path);
     println!("  Workers: {}", cli.workers);
+    println!("  Concurrency per worker: {}", cli.concurrency);
     println!("  Total requests: {}", cli.requests);
     println!("  Duration: {}s", cli.duration);
     println!("  Insecure: {}", cli.insecure);
@@ -90,59 +101,77 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let verbose = cli.verbose;
         let success_status = cli.success_status.clone();
         let requests_per_worker = quotient + if worker_id < remainder { 1 } else { 0 };
+        let concurrency = cli.concurrency;
         let deadline = Arc::clone(&deadline);
 
         let handle = tokio::spawn(async move {
-            let mut client = match client::h3_client::Http3Client::new(insecure) {
-                Ok(c) => c,
-                Err(e) => {
-                    eprintln!("Worker {}: Failed to init client: {}", worker_id, e);
-                    return (0, 0, ErrorStats::default(), HashMap::new(), Vec::new());
-                }
-            };
-
-            // Establish persistent connection once per worker
-            if let Err(e) = client.ensure_connected(&target, port, &host).await {
-                eprintln!("Worker {}: Failed to establish connection: {}", worker_id, e);
-                // Continue anyway, will retry on first request
-            }
-
-            let mut success = 0;
-            let mut fail = 0;
+            let mut success = 0usize;
+            let mut fail = 0usize;
             let mut total_errors = ErrorStats::default();
-            let mut status_codes = HashMap::new();
+            let mut status_codes: HashMap<u16, usize> = HashMap::new();
             let mut latencies = Vec::new();
 
-            for i in 0..requests_per_worker {
-                // Check if we've exceeded the duration deadline
+            // Shared counter of how many requests have been dispatched so far.
+            let dispatched = Arc::new(AtomicUsize::new(0));
+
+            // Spawn a new independent task per in-flight slot; each owns its own
+            // Http3Client so there is no &mut aliasing between concurrent futures.
+            let make_request = |req_index: usize| {
+                let target = target.clone();
+                let host = host.clone();
+                let path = path.clone();
+                let success_status = success_status.clone();
+                tokio::spawn(async move {
+                    let mut c = client::h3_client::Http3Client::new(insecure)
+                        .map_err(|e| format!("init: {e}"))?;
+                    let result = c.send_request(&target, port, &host, &path, verbose)
+                        .await
+                        .map_err(|e| format!("{e}"))?;
+                    let ok = is_success_status(result.status_code, &success_status);
+                    Ok::<_, String>((req_index, ok, result))
+                })
+            };
+
+            // Seed the in-flight set up to `concurrency` slots.
+            let mut in_flight: FuturesUnordered<_> = FuturesUnordered::new();
+            for _ in 0..concurrency {
                 if Instant::now() >= *deadline {
                     break;
                 }
+                let i = dispatched.fetch_add(1, Ordering::Relaxed);
+                if i >= requests_per_worker {
+                    break;
+                }
+                in_flight.push(make_request(i));
+            }
 
-                match client.send_request(&target, port, &host, &path, verbose).await {
-                    Ok(result) => {
-                        // Track status code
+            // Drive the set: as each completes, record the result and backfill.
+            while let Some(join_result) = in_flight.next().await {
+                match join_result {
+                    Ok(Ok((_i, ok, result))) => {
                         *status_codes.entry(result.status_code).or_insert(0) += 1;
-
-                        // Classify as success/fail based on success_status pattern
-                        if is_success_status(result.status_code, &success_status) {
-                            success += 1;
-                        } else {
-                            fail += 1;
-                        }
-
-                        // Accumulate errors
+                        if ok { success += 1; } else { fail += 1; }
                         total_errors.send_errors += result.errors.send_errors;
                         total_errors.recv_errors += result.errors.recv_errors;
                         total_errors.quic_errors += result.errors.quic_errors;
                         total_errors.stream_reset_errors += result.errors.stream_reset_errors;
-
-                        // Record latency
                         latencies.push(result.latency_ms);
                     }
-                    Err(e) => {
-                        eprintln!("Worker {}: Request {} failed: {}", worker_id, i, e);
+                    Ok(Err(e)) => {
+                        eprintln!("Worker {worker_id}: request failed: {e}");
                         fail += 1;
+                    }
+                    Err(e) => {
+                        eprintln!("Worker {worker_id}: task panicked: {e}");
+                        fail += 1;
+                    }
+                }
+
+                // Backfill: try to keep `concurrency` slots busy.
+                if Instant::now() < *deadline {
+                    let i = dispatched.fetch_add(1, Ordering::Relaxed);
+                    if i < requests_per_worker {
+                        in_flight.push(make_request(i));
                     }
                 }
             }


### PR DESCRIPTION
Close- #4 

Previously each worker sent requests strictly sequentially — one await at a time — so a single slow request stalled all further progress for that worker.

This PR replaces the sequential loop with a FuturesUnordered-based pipeline. Each in-flight slot owns its own Http3Client (required since send_request takes &mut self), and slots are backfilled immediately as requests complete, keeping concurrency saturated.

A new -c / --concurrency flag (default 1) controls the number of concurrent in-flight requests per worker, preserving existing behaviour when unset.