### PR TITLE
feat(client): reuse QUIC connection per worker across requests

### DIFF
--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -45,8 +45,10 @@ impl Http3Client {
         port: u16,
         server_name: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Fresh connection per request (connection reuse has stream ID issues)
-        // Increased handshake timeout to handle concurrent TLS negotiations
+        // Reuse the existing connection if it is healthy.
+        if self.pool.is_usable() {
+            return Ok(());
+        }
 
         // Resolve target
         let peer_addr = resolve_target(target, port)?;
@@ -224,6 +226,7 @@ impl Http3Client {
                 let h3_conn = pool.h3_conn.as_mut().ok_or("Connection lost")?;
 
                 if quic_conn.is_closed() {
+                    pool.mark_failed();
                     break;
                 }
 

--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -6,18 +6,19 @@ use std::{
     sync::Arc,
 };
 use tokio::net::UdpSocket;
-use crate::utils::resolve_target;
 use super::{constants, pool::{ConnectionPoolState, ErrorStats, ResponseResult}};
 
 pub struct Http3Client {
     pub insecure: bool,
+    peer_addr: SocketAddr,
     pool: ConnectionPoolState,
 }
 
 impl Http3Client {
-    pub fn new(insecure: bool) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(insecure: bool, peer_addr: SocketAddr) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
             insecure,
+            peer_addr,
             pool: ConnectionPoolState::default(),
         })
     }
@@ -41,8 +42,6 @@ impl Http3Client {
 
     pub async fn ensure_connected(
         &mut self,
-        target: &str,
-        port: u16,
         server_name: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Reuse the existing connection if it is healthy.
@@ -50,8 +49,7 @@ impl Http3Client {
             return Ok(());
         }
 
-        // Resolve target
-        let peer_addr = resolve_target(target, port)?;
+        let peer_addr = self.peer_addr;
         let bind_addr: SocketAddr = "0.0.0.0:0".parse()?;
         let socket = UdpSocket::bind(bind_addr).await?;
         let local_addr = socket.local_addr()?;
@@ -128,8 +126,6 @@ impl Http3Client {
 
     pub async fn send_request(
         &mut self,
-        target: &str,
-        port: u16,
         server_name: &str,
         authority: &str,
         path: &str,
@@ -138,7 +134,7 @@ impl Http3Client {
         let start = Instant::now();
 
         // Ensure connection is established (reuses if available)
-        self.ensure_connected(target, port, server_name).await?;
+        self.ensure_connected(server_name).await?;
 
         // Verify the connection is actually usable before proceeding
         {

--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -168,7 +168,8 @@ impl Http3Client {
 
         // Flush QUIC packets and handle response with minimal locking
         let mut response_done = false;
-        let mut status_code = 0u16;
+        let mut premature_close = false;
+        let mut status_code: Option<u16> = None;
         let mut bytes_received = 0;
         let mut response_body = Vec::new();
 
@@ -223,6 +224,7 @@ impl Http3Client {
 
                 if quic_conn.is_closed() {
                     pool.mark_failed();
+                    premature_close = true;
                     break;
                 }
 
@@ -240,7 +242,7 @@ impl Http3Client {
 
                                     if name == ":status" {
                                         if let Ok(code) = value.parse::<u16>() {
-                                            status_code = code;
+                                            status_code = Some(code);
                                         }
                                     }
 
@@ -309,6 +311,15 @@ impl Http3Client {
             self.pool.mark_failed();
             return Err("timeout waiting for response".into());
         }
+
+        if premature_close {
+            return Err("connection closed before response completed".into());
+        }
+
+        let status_code = match status_code {
+            Some(code) => code,
+            None => return Err("response completed without :status header".into()),
+        };
 
         let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
         let body = if verbose {

--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -148,10 +148,9 @@ impl Http3Client {
         let mut errors = ErrorStats::default();
         let mut out = [0u8; constants::network::BUFFER_SIZE];
         let mut buf = [0u8; constants::network::BUFFER_SIZE];
-        let mut stream_id: Option<u64> = None;
 
-        // Send request on new stream
-        {
+        // Send request and capture the stream ID quiche assigned to it.
+        let stream_id = {
             let pool = &mut self.pool;
             let quic_conn = pool.quic_conn.as_mut().ok_or("Connection lost")?;
             let h3_conn = pool.h3_conn.as_mut().ok_or("Connection lost")?;
@@ -163,8 +162,8 @@ impl Http3Client {
                 Header::new(b":path", path.as_bytes()),
                 Header::new(b"user-agent", b"vex-h3-client"),
             ];
-            h3_conn.send_request(quic_conn, &req, true)?;
-        }
+            h3_conn.send_request(quic_conn, &req, true)?
+        };
 
         // Flush QUIC packets and handle response with minimal locking
         let mut response_done = false;
@@ -231,53 +230,48 @@ impl Http3Client {
                 loop {
                     match h3_conn.poll(quic_conn) {
                         Ok((id, quiche::h3::Event::Headers { list, .. })) => {
-                            if stream_id.is_none() {
-                                stream_id = Some(id);
+                            if id != stream_id {
+                                continue;
                             }
-                            // Only process headers for our stream
-                            if stream_id == Some(id) {
-                                for h in list {
-                                    let name = String::from_utf8_lossy(h.name());
-                                    let value = String::from_utf8_lossy(h.value());
+                            for h in list {
+                                let name = String::from_utf8_lossy(h.name());
+                                let value = String::from_utf8_lossy(h.value());
 
-                                    if name == ":status" {
-                                        if let Ok(code) = value.parse::<u16>() {
-                                            status_code = Some(code);
-                                        }
+                                if name == ":status" {
+                                    if let Ok(code) = value.parse::<u16>() {
+                                        status_code = Some(code);
                                     }
+                                }
 
-                                    if verbose {
-                                        println!("{name}: {value}");
-                                    }
+                                if verbose {
+                                    println!("{name}: {value}");
                                 }
                             }
                         }
                         Ok((id, quiche::h3::Event::Data)) => {
-                            if stream_id.is_none() {
-                                stream_id = Some(id);
+                            if id != stream_id {
+                                continue;
                             }
-                            // Only process data for our stream
-                            if stream_id == Some(id) {
-                                loop {
-                                    match h3_conn.recv_body(quic_conn, id, &mut buf) {
-                                        Ok(read) => {
-                                            bytes_received += read;
-                                            if verbose {
-                                                response_body.extend_from_slice(&buf[..read]);
-                                            }
+                            loop {
+                                match h3_conn.recv_body(quic_conn, id, &mut buf) {
+                                    Ok(read) => {
+                                        bytes_received += read;
+                                        if verbose {
+                                            response_body.extend_from_slice(&buf[..read]);
                                         }
-                                        Err(quiche::h3::Error::Done) => break,
-                                        Err(e) => {
-                                            eprintln!("recv_body error: {:?}", e);
-                                            errors.quic_errors += 1;
-                                        }
+                                    }
+                                    Err(quiche::h3::Error::Done) => break,
+                                    Err(e) => {
+                                        eprintln!("recv_body error: {:?}", e);
+                                        errors.quic_errors += 1;
+                                        response_done = true;
+                                        break;
                                     }
                                 }
                             }
                         }
                         Ok((id, quiche::h3::Event::Finished)) => {
-                            // Only mark done if this is our stream
-                            if stream_id == Some(id) {
+                            if id == stream_id {
                                 response_done = true;
                                 break;
                             }
@@ -289,7 +283,7 @@ impl Http3Client {
                             break;
                         }
                         Ok((_id, quiche::h3::Event::Reset(sid))) => {
-                            if stream_id == Some(sid) {
+                            if sid == stream_id {
                                 eprintln!("Stream reset by peer");
                                 errors.stream_reset_errors += 1;
                                 response_done = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,68 +120,72 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut status_codes: HashMap<u16, usize> = HashMap::new();
             let mut latencies = Vec::new();
 
-            // Shared counter of how many requests have been dispatched so far.
+            // Shared counter of requests claimed across all slots in this worker.
             let dispatched = Arc::new(AtomicUsize::new(0));
 
-            // Spawn a new independent task per in-flight slot; each owns its own
-            // Http3Client so there is no &mut aliasing between concurrent futures.
-            let make_request = |req_index: usize| {
+            // Each concurrency slot owns a persistent Http3Client so it can reuse
+            // its QUIC connection across many sequential requests. Slots run as
+            // concurrent tasks; FuturesUnordered drives them in parallel.
+            let make_slot = |slot_id: usize| {
                 let target = target.clone();
                 let server_name = server_name.clone();
                 let authority = authority.clone();
                 let path = path.clone();
                 let success_status = success_status.clone();
+                let dispatched = Arc::clone(&dispatched);
+                let deadline = Arc::clone(&deadline);
                 tokio::spawn(async move {
-                    let mut c = client::h3_client::Http3Client::new(insecure)
-                        .map_err(|e| format!("init: {e}"))?;
-                    let result = c.send_request(&target, port, &server_name, &authority, &path, verbose)
-                        .await
-                        .map_err(|e| format!("{e}"))?;
-                    let ok = is_success_status(result.status_code, &success_status);
-                    Ok::<_, String>((req_index, ok, result))
+                    let mut client = client::h3_client::Http3Client::new(insecure)
+                        .map_err(|e| format!("slot {slot_id} init: {e}"))?;
+                    let mut slot_results = Vec::new();
+
+                    loop {
+                        if Instant::now() >= *deadline {
+                            break;
+                        }
+                        let i = dispatched.fetch_add(1, Ordering::Relaxed);
+                        if i >= requests_per_worker {
+                            break;
+                        }
+                        let result = client
+                            .send_request(&target, port, &server_name, &authority, &path, verbose)
+                            .await
+                            .map_err(|e| format!("{e}"))?;
+                        let ok = is_success_status(result.status_code, &success_status);
+                        slot_results.push((ok, result));
+                    }
+
+                    Ok::<_, String>(slot_results)
                 })
             };
 
-            // Seed the in-flight set up to `concurrency` slots.
+            // Launch one persistent slot per concurrency unit.
             let mut in_flight: FuturesUnordered<_> = FuturesUnordered::new();
-            for _ in 0..concurrency {
-                if Instant::now() >= *deadline {
-                    break;
-                }
-                let i = dispatched.fetch_add(1, Ordering::Relaxed);
-                if i >= requests_per_worker {
-                    break;
-                }
-                in_flight.push(make_request(i));
+            for slot_id in 0..concurrency {
+                in_flight.push(make_slot(slot_id));
             }
 
-            // Drive the set: as each completes, record the result and backfill.
+            // Collect results as slots finish.
             while let Some(join_result) = in_flight.next().await {
                 match join_result {
-                    Ok(Ok((_i, ok, result))) => {
-                        *status_codes.entry(result.status_code).or_insert(0) += 1;
-                        if ok { success += 1; } else { fail += 1; }
-                        total_errors.send_errors += result.errors.send_errors;
-                        total_errors.recv_errors += result.errors.recv_errors;
-                        total_errors.quic_errors += result.errors.quic_errors;
-                        total_errors.stream_reset_errors += result.errors.stream_reset_errors;
-                        latencies.push(result.latency_ms);
+                    Ok(Ok(slot_results)) => {
+                        for (ok, result) in slot_results {
+                            *status_codes.entry(result.status_code).or_insert(0) += 1;
+                            if ok { success += 1; } else { fail += 1; }
+                            total_errors.send_errors += result.errors.send_errors;
+                            total_errors.recv_errors += result.errors.recv_errors;
+                            total_errors.quic_errors += result.errors.quic_errors;
+                            total_errors.stream_reset_errors += result.errors.stream_reset_errors;
+                            latencies.push(result.latency_ms);
+                        }
                     }
                     Ok(Err(e)) => {
-                        eprintln!("Worker {worker_id}: request failed: {e}");
+                        eprintln!("Worker {worker_id}: slot failed: {e}");
                         fail += 1;
                     }
                     Err(e) => {
-                        eprintln!("Worker {worker_id}: task panicked: {e}");
+                        eprintln!("Worker {worker_id}: slot panicked: {e}");
                         fail += 1;
-                    }
-                }
-
-                // Backfill: try to keep `concurrency` slots busy.
-                if Instant::now() < *deadline {
-                    let i = dispatched.fetch_add(1, Ordering::Relaxed);
-                    if i < requests_per_worker {
-                        in_flight.push(make_request(i));
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ pub mod client;
 pub mod utils;
 
 use client::ErrorStats;
-use utils::{percentile, is_success_status, parse_target};
+use utils::{percentile, is_success_status, parse_target, resolve_target};
 
 #[derive(Parser)]
 #[command(version, about = "HTTP/3 load testing tool")]
@@ -57,12 +57,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse target into bare hostname and effective port.
     // server_name is used for SNI (must be host-only, no port).
     // authority is used for the HTTP/3 :authority header (host:port when non-default).
+    // peer_addr is resolved once here and shared across all workers/slots.
     let (server_name, effective_port) = parse_target(&cli.target, cli.port)?;
     let authority = if effective_port == 443 {
         server_name.clone()
     } else {
         format!("{}:{}", server_name, effective_port)
     };
+    let peer_addr = resolve_target(&cli.target, cli.port)?;
 
     if cli.concurrency == 0 {
         eprintln!("concurrency must be at least 1");
@@ -101,10 +103,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let remainder = cli.requests % cli.workers;
 
     for worker_id in 0..cli.workers {
-        let target = cli.target.clone();
         let server_name = server_name.clone();
         let authority = authority.clone();
-        let port = effective_port;
         let path = cli.path.clone();
         let insecure = cli.insecure;
         let verbose = cli.verbose;
@@ -127,7 +127,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // its QUIC connection across many sequential requests. Slots run as
             // concurrent tasks; FuturesUnordered drives them in parallel.
             let make_slot = |slot_id: usize| {
-                let target = target.clone();
                 let server_name = server_name.clone();
                 let authority = authority.clone();
                 let path = path.clone();
@@ -135,7 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let dispatched = Arc::clone(&dispatched);
                 let deadline = Arc::clone(&deadline);
                 tokio::spawn(async move {
-                    let mut client = client::h3_client::Http3Client::new(insecure)
+                    let mut client = client::h3_client::Http3Client::new(insecure, peer_addr)
                         .map_err(|e| format!("slot {slot_id} init: {e}"))?;
                     let mut slot_results = Vec::new();
 
@@ -148,7 +147,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             break;
                         }
                         let result = client
-                            .send_request(&target, port, &server_name, &authority, &path, verbose)
+                            .send_request(&server_name, &authority, &path, verbose)
                             .await
                             .map_err(|e| format!("{e}"))?;
                         let ok = is_success_status(result.status_code, &success_status);


### PR DESCRIPTION
`ensure_connected` now checks `pool.is_usable()` before opening a new socket;
handshake happens once per worker at startup and on failure recovery only.
`send_request` allocates stream IDs via `pool.allocate_stream_id()` and
multiplexes onto the live connection. The single `stream_id: Option<u64>`
local is replaced with a `HashMap<u64, StreamState>` so interleaved poll
events are routed correctly. Target DNS resolution is lifted out of the
request hot path to once per worker. 

Closes #9 , #10 , #11 