### PR TITLE
fix: harden QUIC connection reuse and recv error handling

### DIFF
--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -1,12 +1,20 @@
 use quiche::{self, h3::{Header, NameValue}};
 use rand::RngCore;
 use std::{
-    net::SocketAddr,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     time::{Duration, Instant},
     sync::Arc,
 };
 use tokio::net::UdpSocket;
 use super::{constants, pool::{ConnectionPoolState, ErrorStats, ResponseResult}};
+
+fn bind_addr_for_peer(peer_addr: SocketAddr) -> SocketAddr {
+    if peer_addr.is_ipv6() {
+        SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0))
+    } else {
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))
+    }
+}
 
 pub struct Http3Client {
     pub insecure: bool,
@@ -50,7 +58,7 @@ impl Http3Client {
         }
 
         let peer_addr = self.peer_addr;
-        let bind_addr: SocketAddr = "0.0.0.0:0".parse()?;
+        let bind_addr = bind_addr_for_peer(peer_addr);
         let socket = UdpSocket::bind(bind_addr).await?;
         let local_addr = socket.local_addr()?;
 
@@ -102,10 +110,15 @@ impl Http3Client {
             match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
                 Ok(Ok((len, from))) => {
                     let recv_info = quiche::RecvInfo { from, to: local_addr };
-                    let _ = quic_conn.recv(&mut buf[..len], recv_info);
+                    match quic_conn.recv(&mut buf[..len], recv_info) {
+                        Ok(_) | Err(quiche::Error::Done) => {}
+                        Err(err) => {
+                            return Err(format!("quic recv failed during handshake: {:?}", err).into());
+                        }
+                    }
                 }
-                Ok(Err(_)) => {
-                    return Err("socket recv failed".into());
+                Ok(Err(err)) => {
+                    return Err(format!("socket recv failed during handshake: {}", err).into());
                 }
                 Err(_) => {
                     quic_conn.on_timeout();
@@ -189,7 +202,13 @@ impl Http3Client {
                 match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
                     Ok(Ok((len, from))) => {
                         let recv_info = quiche::RecvInfo { from, to: local_addr };
-                        let _ = quic_conn.recv(&mut buf[..len], recv_info);
+                        match quic_conn.recv(&mut buf[..len], recv_info) {
+                            Ok(_) | Err(quiche::Error::Done) => {}
+                            Err(err) => {
+                                eprintln!("quic recv failed: {:?}", err);
+                                errors.quic_errors += 1;
+                            }
+                        }
                     }
                     Ok(Err(e)) => {
                         eprintln!("socket recv_from error: {}", e);
@@ -237,10 +256,10 @@ impl Http3Client {
                                 let name = String::from_utf8_lossy(h.name());
                                 let value = String::from_utf8_lossy(h.value());
 
-                                if name == ":status" {
-                                    if let Ok(code) = value.parse::<u16>() {
-                                        status_code = Some(code);
-                                    }
+                                if name == ":status"
+                                    && let Ok(code) = value.parse::<u16>()
+                                {
+                                    status_code = Some(code);
                                 }
 
                                 if verbose {
@@ -329,5 +348,25 @@ impl Http3Client {
             latency_ms,
             body,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bind_addr_for_peer;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    #[test]
+    fn bind_addr_matches_ipv4_peer_family() {
+        let peer = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 10), 443));
+        let bind = bind_addr_for_peer(peer);
+        assert!(bind.is_ipv4());
+    }
+
+    #[test]
+    fn bind_addr_matches_ipv6_peer_family() {
+        let peer = SocketAddr::from((Ipv6Addr::LOCALHOST, 443));
+        let bind = bind_addr_for_peer(peer);
+        assert!(bind.is_ipv6());
     }
 }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -28,6 +28,7 @@ pub struct ResponseResult {
 /// Maintains a single QUIC connection and H3 connection for reuse across
 /// multiple requests within a worker task. Connection is fresh per request;
 /// reuse_count tracks how many requests this worker has dispatched.
+#[derive(Default)]
 pub struct ConnectionPoolState {
     pub quic_conn: Option<quiche::Connection>,
     pub h3_conn: Option<h3::Connection>,
@@ -38,20 +39,6 @@ pub struct ConnectionPoolState {
     pub failed: bool,
 }
 
-impl Default for ConnectionPoolState {
-    fn default() -> Self {
-        Self {
-            quic_conn: None,
-            h3_conn: None,
-            socket: None,
-            local_addr: None,
-            peer_addr: None,
-            reuse_count: 0,
-            failed: false,
-        }
-    }
-}
-
 impl ConnectionPoolState {
     /// Mark connection as failed (e.g., after GOAWAY or timeout)
     pub fn mark_failed(&mut self) {
@@ -60,6 +47,11 @@ impl ConnectionPoolState {
 
     /// Check if connection should be reused
     pub fn is_usable(&self) -> bool {
-        self.quic_conn.is_some() && self.h3_conn.is_some() && self.socket.is_some() && !self.failed
+        let quic_open = self
+            .quic_conn
+            .as_ref()
+            .is_some_and(|quic_conn| !quic_conn.is_closed());
+
+        quic_open && self.h3_conn.is_some() && self.socket.is_some() && !self.failed
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -130,22 +130,22 @@ pub fn percentile(sorted_values: &[f64], p: f64) -> f64 {
 pub fn is_success_status(status_code: u16, success_pattern: &str) -> bool {
     for part in success_pattern.split(',') {
         let part = part.trim();
-        if part == "2xx" && status_code >= 200 && status_code < 300 {
+        if part == "2xx" && (200..300).contains(&status_code) {
             return true;
         }
-        if part == "3xx" && status_code >= 300 && status_code < 400 {
+        if part == "3xx" && (300..400).contains(&status_code) {
             return true;
         }
-        if part == "4xx" && status_code >= 400 && status_code < 500 {
+        if part == "4xx" && (400..500).contains(&status_code) {
             return true;
         }
-        if part == "5xx" && status_code >= 500 && status_code < 600 {
+        if part == "5xx" && (500..600).contains(&status_code) {
             return true;
         }
-        if let Ok(code) = part.parse::<u16>() {
-            if status_code == code {
-                return true;
-            }
+        if let Ok(code) = part.parse::<u16>()
+            && status_code == code
+        {
+            return true;
         }
     }
     false


### PR DESCRIPTION
## Summary
This PR closes three P0 reliability issues in the QUIC client path:

1. Prevents reuse of closed QUIC connections.
2. Binds UDP sockets using the resolved peer address family (IPv4/IPv6).
3. Stops discarding `quic_conn.recv()` errors and classifies them explicitly.

## Changes
- `ConnectionPoolState::is_usable()` now checks that `quic_conn` exists and is not closed.
- Added peer-family-aware bind helper:
  - IPv4 peer -> `0.0.0.0:0`
  - IPv6 peer -> `[::]:0`
- In both recv loops:
  - `Err(Done)` is treated as non-fatal.
  - Other QUIC recv errors are handled explicitly:
    - handshake loop returns a clear connection error.
    - request loop increments `quic_errors` and logs the protocol failure.
- Added unit tests validating bind address family selection.
- Included minimal clippy-driven cleanup in success-status matching to keep lint gate green.

## Validation
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
Both pass.
