### PR TITLE
fix(client): handle server-close-after-response and cap poll timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,43 @@ The completion reason is reported in the output. If the duration expires before 
 
 ---
 
+## Benchmarks
+
+Measured on 2026-04-24 against `google.com` (HTTP/3, redirects counted as success):
+
+```
+cargo run --release -- --target google.com --insecure \
+  --success-status 2xx,3xx -n 1000 --workers 10 -c 100
+```
+
+```
+Total time:         1.10s
+Total requests:     1000
+Successful:         1000
+Failed:             0
+Requests/sec:       907.55
+Completion reason:  All 1000 requests completed
+
+HTTP Status code breakdown:
+  302: 3xx Redirect (1000)
+
+Latency metrics (ms):
+  Min:   283.63
+  Max:  1052.91
+  Avg:   690.64
+  p50:   685.00
+  p90:   854.11
+  p95:   864.72
+  p99:   930.92
+```
+
+> Google closes the QUIC connection after every response, so each request
+> pays a full TLS+QUIC handshake (~300-1000ms). The 907 req/s figure
+> reflects 10 workers × 100 concurrent streams saturating the reconnect
+> pipeline in parallel.
+
+---
+
 ## Dependencies
 
 - Tokio - Async runtime for concurrent request handling

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -51,6 +51,52 @@ Latency metrics (ms):
 
 ---
 
+## google.com — 10000 requests, 100 workers, 1000 concurrency
+
+```bash
+cargo run --release -- --target google.com --insecure \
+  --success-status 2xx,3xx -n 10000 --workers 100 -c 1000
+```
+
+```
+Starting HTTP/3 load test:
+  Target: google.com:443
+  Host: google.com
+  Path: /
+  Workers: 100
+  Concurrency per worker: 1000
+  Total requests: 10000
+  Duration: 30s
+  Insecure: true
+
+Load test completed:
+  Total time: 8.62s
+  Total requests: 10000
+  Successful requests: 10000
+  Failed requests: 0
+  Requests/sec: 1159.92
+  Completion reason: All 10000 requests completed
+
+HTTP Status code breakdown:
+  302: 3xx Redirect (10000)
+
+Latency metrics (ms):
+  Min:   308.18
+  Max:  3806.45
+  Avg:  1574.87
+  p50:  1434.02
+  p90:  2579.17
+  p95:  2667.30
+  p99:  2795.15
+```
+
+**Notes:**
+- 10× the requests at 10× the concurrency completes in 8.6s with zero failures.
+- Higher p99 (2.8s vs 0.9s) reflects queuing at the reconnect layer — each of the 100 workers is cycling through 1000 concurrent connections against a server that closes after every response.
+- Throughput scales from ~907 to ~1160 req/s as more workers absorb handshake latency in parallel.
+
+---
+
 ## Interpreting Results
 
 | Metric | What it tells you |

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,64 @@
+# Benchmark Results
+
+Results captured on 2026-04-24 using the release build.
+
+---
+
+## google.com — 1000 requests, 10 workers, 100 concurrency
+
+```bash
+cargo run --release -- --target google.com --insecure \
+  --success-status 2xx,3xx -n 1000 --workers 10 -c 100
+```
+
+```
+Starting HTTP/3 load test:
+  Target: google.com:443
+  Host: google.com
+  Path: /
+  Workers: 10
+  Concurrency per worker: 100
+  Total requests: 1000
+  Duration: 30s
+  Insecure: true
+
+Load test completed:
+  Total time: 1.10s
+  Total requests: 1000
+  Successful requests: 1000
+  Failed requests: 0
+  Requests/sec: 907.55
+  Completion reason: All 1000 requests completed
+
+HTTP Status code breakdown:
+  302: 3xx Redirect (1000)
+
+Latency metrics (ms):
+  Min:   283.63
+  Max:  1052.91
+  Avg:   690.64
+  p50:   685.00
+  p90:   854.11
+  p95:   864.72
+  p99:   930.92
+```
+
+**Notes:**
+- Google closes the QUIC connection after every response (one request per connection).
+- Each request pays a full TLS+QUIC handshake round trip (~300-1000ms to Google's servers).
+- Throughput of ~907 req/s is achieved by running 10 workers × 100 concurrent streams in parallel, saturating the reconnect pipeline.
+- Latency figures reflect handshake cost, not server processing time. A server that reuses connections will show much lower p50/p99.
+
+---
+
+## Interpreting Results
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `Requests/sec` | Overall throughput across all workers |
+| `p50` | Median request latency — typical user experience |
+| `p90` / `p95` | Tail latency — affects 1 in 10 / 1 in 20 requests |
+| `p99` | Worst-tail latency — affects 1 in 100 requests |
+| `Failed requests` | Requests that did not receive a valid response |
+
+A healthy server with persistent QUIC connections will show latency well under 100ms p99 and near-zero failed requests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - Usage:
       - Examples: EXAMPLES.md
       - Metrics & Output: METRICS.md
+      - Benchmarks: BENCHMARKS.md
 
 markdown_extensions:
   - admonition

--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -71,9 +71,11 @@ impl Http3Client {
             return Ok(());
         }
 
-        // Discard any in-flight state from the dead connection.
+        // poll_once drains in_flight before returning false, so by the time
+        // ensure_connected is called there should be no orphaned streams.
+        // Drain defensively in case ensure_connected is called from other paths.
         for (_, state) in self.in_flight.drain() {
-            let _ = state.tx.send(Err("connection reset before stream completed".into()));
+            let _ = state.tx.send(Err("connection replaced before stream completed".into()));
         }
 
         let peer_addr = self.peer_addr;
@@ -117,7 +119,8 @@ impl Http3Client {
                 h3_conn = Some(quiche::h3::Connection::with_transport(&mut quic_conn, &h3_config)?);
             }
 
-            let timeout = quic_conn.timeout().unwrap_or(Duration::from_millis(constants::network::HANDSHAKE_POLL_TIMEOUT_MS));
+            let quic_timeout = quic_conn.timeout().unwrap_or(Duration::from_millis(constants::network::HANDSHAKE_POLL_TIMEOUT_MS));
+            let timeout = quic_timeout.min(Duration::from_millis(constants::network::HANDSHAKE_POLL_TIMEOUT_MS));
             match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
                 Ok(Ok((len, from))) => {
                     let recv_info = quiche::RecvInfo { from, to: local_addr };
@@ -189,51 +192,54 @@ impl Http3Client {
             _ => return false,
         };
 
+        let connection_closed;
         {
             let quic_conn = match self.pool.quic_conn.as_mut() {
                 Some(c) => c,
                 None => return false,
             };
 
-            if quic_conn.is_closed() {
-                self.pool.mark_failed();
-                return false;
-            }
+            if !quic_conn.is_closed() {
+                let quic_timeout = quic_conn.timeout()
+                    .unwrap_or(Duration::from_millis(constants::network::RESPONSE_POLL_TIMEOUT_MS));
+                let timeout = quic_timeout.min(Duration::from_millis(constants::network::RESPONSE_POLL_TIMEOUT_MS));
 
-            let timeout = quic_conn.timeout()
-                .unwrap_or(Duration::from_millis(constants::network::RESPONSE_POLL_TIMEOUT_MS));
-
-            match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
-                Ok(Ok((len, from))) => {
-                    let recv_info = quiche::RecvInfo { from, to: local_addr };
-                    if let Err(e) = quic_conn.recv(&mut buf[..len], recv_info) {
-                        if e != quiche::Error::Done {
-                            // Propagate quic error to all waiters.
-                            self.pool.mark_failed();
-                            let msg = format!("quic recv error: {:?}", e);
-                            for (_, state) in self.in_flight.drain() {
-                                let _ = state.tx.send(Err(msg.clone()));
+                match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
+                    Ok(Ok((len, from))) => {
+                        let recv_info = quiche::RecvInfo { from, to: local_addr };
+                        if let Err(e) = quic_conn.recv(&mut buf[..len], recv_info) {
+                            if e != quiche::Error::Done {
+                                // Propagate quic error to all waiters.
+                                self.pool.mark_failed();
+                                let msg = format!("quic recv error: {:?}", e);
+                                for (_, state) in self.in_flight.drain() {
+                                    let _ = state.tx.send(Err(msg.clone()));
+                                }
+                                return false;
                             }
-                            return false;
                         }
                     }
+                    Ok(Err(_)) => {}
+                    Err(_) => { quic_conn.on_timeout(); }
                 }
-                Ok(Err(_)) => {}
-                Err(_) => { quic_conn.on_timeout(); }
+
+                loop {
+                    match quic_conn.send(&mut out) {
+                        Ok((write, send_info)) => {
+                            let _ = socket.send_to(&out[..write], send_info.to).await;
+                        }
+                        Err(quiche::Error::Done) | Err(_) => break,
+                    }
+                }
             }
 
-            loop {
-                match quic_conn.send(&mut out) {
-                    Ok((write, send_info)) => {
-                        let _ = socket.send_to(&out[..write], send_info.to).await;
-                    }
-                    Err(quiche::Error::Done) | Err(_) => break,
-                }
-            }
+            // Re-check after processing — recv may have caused connection close.
+            connection_closed = quic_conn.is_closed();
         }
 
         // Drain H3 events and route to per-stream state.
         let mut finished_streams: Vec<u64> = Vec::new();
+        let mut got_goaway = false;
 
         {
             let quic_conn = match self.pool.quic_conn.as_mut() {
@@ -287,12 +293,9 @@ impl Http3Client {
                         finished_streams.push(id);
                     }
                     Ok((_id, quiche::h3::Event::GoAway)) => {
-                        self.pool.mark_failed();
-                        let msg = "connection received GOAWAY".to_string();
-                        for (_, state) in self.in_flight.drain() {
-                            let _ = state.tx.send(Err(msg.clone()));
-                        }
-                        return false;
+                        // Mark failed after the borrow scope ends — GoAway means
+                        // "don't open new streams", not "abort existing ones".
+                        got_goaway = true;
                     }
                     Ok((_id, quiche::h3::Event::Reset(sid))) => {
                         if let Some(mut state) = self.in_flight.remove(&sid) {
@@ -308,6 +311,10 @@ impl Http3Client {
                     }
                 }
             }
+        }
+
+        if got_goaway {
+            self.pool.mark_failed();
         }
 
         // Resolve finished streams.
@@ -330,6 +337,17 @@ impl Http3Client {
                 };
                 let _ = state.tx.send(result);
             }
+        }
+
+        if connection_closed {
+            self.pool.mark_failed();
+            // Any streams that didn't get a Finished event before the connection
+            // closed will never complete on this connection. Signal them so their
+            // tasks unblock; callers should retry these streams.
+            for (_, state) in self.in_flight.drain() {
+                let _ = state.tx.send(Err("connection replaced before stream completed".into()));
+            }
+            return false;
         }
 
         true

--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -1,11 +1,12 @@
 use quiche::{self, h3::{Header, NameValue}};
 use rand::RngCore;
 use std::{
+    collections::HashMap,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     time::{Duration, Instant},
     sync::Arc,
 };
-use tokio::net::UdpSocket;
+use tokio::{net::UdpSocket, sync::oneshot};
 use super::{constants, pool::{ConnectionPoolState, ErrorStats, ResponseResult}};
 
 fn bind_addr_for_peer(peer_addr: SocketAddr) -> SocketAddr {
@@ -16,10 +17,23 @@ fn bind_addr_for_peer(peer_addr: SocketAddr) -> SocketAddr {
     }
 }
 
+// Per-stream state accumulated while the poll loop runs.
+struct StreamState {
+    status_code: Option<u16>,
+    bytes_received: usize,
+    body: Vec<u8>,
+    errors: ErrorStats,
+    start: Instant,
+    verbose: bool,
+    tx: oneshot::Sender<Result<ResponseResult, String>>,
+}
+
 pub struct Http3Client {
     pub insecure: bool,
     peer_addr: SocketAddr,
     pool: ConnectionPoolState,
+    // In-flight streams waiting for their Finished event.
+    in_flight: HashMap<u64, StreamState>,
 }
 
 impl Http3Client {
@@ -28,6 +42,7 @@ impl Http3Client {
             insecure,
             peer_addr,
             pool: ConnectionPoolState::default(),
+            in_flight: HashMap::new(),
         })
     }
 
@@ -52,9 +67,13 @@ impl Http3Client {
         &mut self,
         server_name: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Reuse the existing connection if it is healthy.
         if self.pool.is_usable() {
             return Ok(());
+        }
+
+        // Discard any in-flight state from the dead connection.
+        for (_, state) in self.in_flight.drain() {
+            let _ = state.tx.send(Err("connection reset before stream completed".into()));
         }
 
         let peer_addr = self.peer_addr;
@@ -62,7 +81,6 @@ impl Http3Client {
         let socket = UdpSocket::bind(bind_addr).await?;
         let local_addr = socket.local_addr()?;
 
-        // Create new QUIC connection
         let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
         rand::thread_rng().fill_bytes(&mut scid_bytes);
         let scid = quiche::ConnectionId::from_ref(&scid_bytes);
@@ -70,7 +88,6 @@ impl Http3Client {
         let mut config = self.build_quic_config()?;
         let mut quic_conn = quiche::connect(Some(server_name), &scid, local_addr, peer_addr, &mut config)?;
 
-        // Perform handshake
         let mut out = [0u8; constants::network::BUFFER_SIZE];
         let mut buf = [0u8; constants::network::BUFFER_SIZE];
         let handshake_deadline = Instant::now() + Duration::from_secs(constants::network::HANDSHAKE_TIMEOUT_SECS);
@@ -85,48 +102,35 @@ impl Http3Client {
                 break;
             }
 
-            // Give other tasks a chance to run
             tokio::task::yield_now().await;
 
-            // Send pending packets
             loop {
                 match quic_conn.send(&mut out) {
-                    Ok((write, send_info)) => {
-                        socket.send_to(&out[..write], send_info.to).await?;
-                    }
+                    Ok((write, send_info)) => { socket.send_to(&out[..write], send_info.to).await?; }
                     Err(quiche::Error::Done) => break,
                     Err(e) => return Err(format!("send failed: {:?}", e).into()),
                 }
             }
 
-            // Initialize H3 once established
             if quic_conn.is_established() && h3_conn.is_none() {
                 let h3_config = quiche::h3::Config::new()?;
                 h3_conn = Some(quiche::h3::Connection::with_transport(&mut quic_conn, &h3_config)?);
             }
 
-            // Receive packets with timeout
             let timeout = quic_conn.timeout().unwrap_or(Duration::from_millis(constants::network::HANDSHAKE_POLL_TIMEOUT_MS));
             match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
                 Ok(Ok((len, from))) => {
                     let recv_info = quiche::RecvInfo { from, to: local_addr };
                     match quic_conn.recv(&mut buf[..len], recv_info) {
                         Ok(_) | Err(quiche::Error::Done) => {}
-                        Err(err) => {
-                            return Err(format!("quic recv failed during handshake: {:?}", err).into());
-                        }
+                        Err(err) => return Err(format!("quic recv failed during handshake: {:?}", err).into()),
                     }
                 }
-                Ok(Err(err)) => {
-                    return Err(format!("socket recv failed during handshake: {}", err).into());
-                }
-                Err(_) => {
-                    quic_conn.on_timeout();
-                }
+                Ok(Err(err)) => return Err(format!("socket recv failed during handshake: {}", err).into()),
+                Err(_) => { quic_conn.on_timeout(); }
             }
         }
 
-        // Store in pool
         self.pool.quic_conn = Some(quic_conn);
         self.pool.h3_conn = h3_conn;
         self.pool.socket = Some(Arc::new(socket));
@@ -137,6 +141,210 @@ impl Http3Client {
         Ok(())
     }
 
+    // Dispatch one HTTP/3 stream and return a receiver that resolves when the
+    // stream's Finished event arrives. The caller must drive the connection
+    // (via `poll_once`) while awaiting the receiver.
+    pub fn dispatch(
+        &mut self,
+        authority: &str,
+        path: &str,
+        verbose: bool,
+    ) -> Result<(u64, oneshot::Receiver<Result<ResponseResult, String>>), Box<dyn std::error::Error>> {
+        let pool = &mut self.pool;
+        let quic_conn = pool.quic_conn.as_mut().ok_or("Connection lost")?;
+        let h3_conn = pool.h3_conn.as_mut().ok_or("Connection lost")?;
+
+        let req = vec![
+            Header::new(b":method", b"GET"),
+            Header::new(b":scheme", b"https"),
+            Header::new(b":authority", authority.as_bytes()),
+            Header::new(b":path", path.as_bytes()),
+            Header::new(b"user-agent", b"vex-h3-client"),
+        ];
+        let stream_id = h3_conn.send_request(quic_conn, &req, true)?;
+
+        let (tx, rx) = oneshot::channel();
+        self.in_flight.insert(stream_id, StreamState {
+            status_code: None,
+            bytes_received: 0,
+            body: Vec::new(),
+            errors: ErrorStats::default(),
+            start: Instant::now(),
+            verbose,
+            tx,
+        });
+
+        Ok((stream_id, rx))
+    }
+
+    // Run one iteration of the QUIC I/O + H3 poll loop, routing events to
+    // their waiting StreamState entries. Returns true if the connection is
+    // still alive.
+    pub async fn poll_once(&mut self) -> bool {
+        let mut buf = [0u8; constants::network::BUFFER_SIZE];
+        let mut out = [0u8; constants::network::BUFFER_SIZE];
+
+        let (socket, local_addr) = match (self.pool.socket.clone(), self.pool.local_addr) {
+            (Some(s), Some(a)) => (s, a),
+            _ => return false,
+        };
+
+        {
+            let quic_conn = match self.pool.quic_conn.as_mut() {
+                Some(c) => c,
+                None => return false,
+            };
+
+            if quic_conn.is_closed() {
+                self.pool.mark_failed();
+                return false;
+            }
+
+            let timeout = quic_conn.timeout()
+                .unwrap_or(Duration::from_millis(constants::network::RESPONSE_POLL_TIMEOUT_MS));
+
+            match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
+                Ok(Ok((len, from))) => {
+                    let recv_info = quiche::RecvInfo { from, to: local_addr };
+                    if let Err(e) = quic_conn.recv(&mut buf[..len], recv_info) {
+                        if e != quiche::Error::Done {
+                            // Propagate quic error to all waiters.
+                            self.pool.mark_failed();
+                            let msg = format!("quic recv error: {:?}", e);
+                            for (_, state) in self.in_flight.drain() {
+                                let _ = state.tx.send(Err(msg.clone()));
+                            }
+                            return false;
+                        }
+                    }
+                }
+                Ok(Err(_)) => {}
+                Err(_) => { quic_conn.on_timeout(); }
+            }
+
+            loop {
+                match quic_conn.send(&mut out) {
+                    Ok((write, send_info)) => {
+                        let _ = socket.send_to(&out[..write], send_info.to).await;
+                    }
+                    Err(quiche::Error::Done) | Err(_) => break,
+                }
+            }
+        }
+
+        // Drain H3 events and route to per-stream state.
+        let mut finished_streams: Vec<u64> = Vec::new();
+
+        {
+            let quic_conn = match self.pool.quic_conn.as_mut() {
+                Some(c) => c,
+                None => return false,
+            };
+            let h3_conn = match self.pool.h3_conn.as_mut() {
+                Some(c) => c,
+                None => return false,
+            };
+
+            loop {
+                match h3_conn.poll(quic_conn) {
+                    Ok((id, quiche::h3::Event::Headers { list, .. })) => {
+                        if let Some(state) = self.in_flight.get_mut(&id) {
+                            for h in list {
+                                let name = String::from_utf8_lossy(h.name());
+                                let value = String::from_utf8_lossy(h.value());
+                                if name == ":status" {
+                                    if let Ok(code) = value.parse::<u16>() {
+                                        state.status_code = Some(code);
+                                    }
+                                }
+                                if state.verbose {
+                                    println!("{name}: {value}");
+                                }
+                            }
+                        }
+                    }
+                    Ok((id, quiche::h3::Event::Data)) => {
+                        if let Some(state) = self.in_flight.get_mut(&id) {
+                            loop {
+                                match h3_conn.recv_body(quic_conn, id, &mut buf) {
+                                    Ok(read) => {
+                                        state.bytes_received += read;
+                                        if state.verbose {
+                                            state.body.extend_from_slice(&buf[..read]);
+                                        }
+                                    }
+                                    Err(quiche::h3::Error::Done) => break,
+                                    Err(e) => {
+                                        state.errors.quic_errors += 1;
+                                        eprintln!("recv_body error on stream {id}: {:?}", e);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok((id, quiche::h3::Event::Finished)) => {
+                        finished_streams.push(id);
+                    }
+                    Ok((_id, quiche::h3::Event::GoAway)) => {
+                        self.pool.mark_failed();
+                        let msg = "connection received GOAWAY".to_string();
+                        for (_, state) in self.in_flight.drain() {
+                            let _ = state.tx.send(Err(msg.clone()));
+                        }
+                        return false;
+                    }
+                    Ok((_id, quiche::h3::Event::Reset(sid))) => {
+                        if let Some(mut state) = self.in_flight.remove(&sid) {
+                            state.errors.stream_reset_errors += 1;
+                            let _ = state.tx.send(Err(format!("stream {sid} reset by peer")));
+                        }
+                    }
+                    Ok((_id, quiche::h3::Event::PriorityUpdate)) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => {
+                        eprintln!("h3 poll error: {:?}", e);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Resolve finished streams.
+        for id in finished_streams {
+            if let Some(state) = self.in_flight.remove(&id) {
+                let latency_ms = state.start.elapsed().as_secs_f64() * 1000.0;
+                let result = match state.status_code {
+                    None => Err("stream finished without :status header".into()),
+                    Some(code) => Ok(ResponseResult {
+                        status_code: code,
+                        bytes_received: state.bytes_received,
+                        errors: state.errors,
+                        latency_ms,
+                        body: if state.verbose {
+                            Some(String::from_utf8_lossy(&state.body).into_owned())
+                        } else {
+                            None
+                        },
+                    }),
+                };
+                let _ = state.tx.send(result);
+            }
+        }
+
+        true
+    }
+
+    pub fn has_in_flight(&self) -> bool {
+        !self.in_flight.is_empty()
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.pool.is_usable()
+    }
+
+    // High-level send_request: dispatch + drive until this stream resolves.
+    // Used when the caller wants a simple sequential interface.
     pub async fn send_request(
         &mut self,
         server_name: &str,
@@ -144,210 +352,46 @@ impl Http3Client {
         path: &str,
         verbose: bool,
     ) -> Result<ResponseResult, Box<dyn std::error::Error>> {
-        let start = Instant::now();
-
-        // Ensure connection is established (reuses if available)
         self.ensure_connected(server_name).await?;
 
-        // Verify the connection is actually usable before proceeding
-        {
-            let pool = &mut self.pool;
-            if !pool.is_usable() {
-                return Err("Connection lost".into());
-            }
-            pool.reuse_count += 1;
+        if !self.pool.is_usable() {
+            return Err("Connection lost".into());
         }
+        self.pool.reuse_count += 1;
 
-        let mut errors = ErrorStats::default();
-        let mut out = [0u8; constants::network::BUFFER_SIZE];
-        let mut buf = [0u8; constants::network::BUFFER_SIZE];
+        let (_stream_id, mut rx) = self.dispatch(authority, path, verbose)?;
 
-        // Send request and capture the stream ID quiche assigned to it.
-        let stream_id = {
-            let pool = &mut self.pool;
-            let quic_conn = pool.quic_conn.as_mut().ok_or("Connection lost")?;
-            let h3_conn = pool.h3_conn.as_mut().ok_or("Connection lost")?;
+        let deadline = Instant::now() + Duration::from_secs(constants::network::RESPONSE_TIMEOUT_SECS);
 
-            let req = vec![
-                Header::new(b":method", b"GET"),
-                Header::new(b":scheme", b"https"),
-                Header::new(b":authority", authority.as_bytes()),
-                Header::new(b":path", path.as_bytes()),
-                Header::new(b"user-agent", b"vex-h3-client"),
-            ];
-            h3_conn.send_request(quic_conn, &req, true)?
-        };
-
-        // Flush QUIC packets and handle response with minimal locking
-        let mut response_done = false;
-        let mut premature_close = false;
-        let mut status_code: Option<u16> = None;
-        let mut bytes_received = 0;
-        let mut response_body = Vec::new();
-
-        while !response_done && start.elapsed() < Duration::from_secs(constants::network::RESPONSE_TIMEOUT_SECS) {
-            // Get socket and local_addr outside the critical section
-            let (socket, local_addr) = {
-                let pool = &self.pool;
-                (pool.socket.clone().ok_or("Socket lost")?, pool.local_addr.ok_or("Addr lost")?)
-            };
-
-            // Receive and process packets
-            {
-                let pool = &mut self.pool;
-                let quic_conn = pool.quic_conn.as_mut().ok_or("Connection lost")?;
-
-                let timeout = quic_conn.timeout().unwrap_or(Duration::from_millis(constants::network::RESPONSE_POLL_TIMEOUT_MS));
-
-                match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
-                    Ok(Ok((len, from))) => {
-                        let recv_info = quiche::RecvInfo { from, to: local_addr };
-                        match quic_conn.recv(&mut buf[..len], recv_info) {
-                            Ok(_) | Err(quiche::Error::Done) => {}
-                            Err(err) => {
-                                eprintln!("quic recv failed: {:?}", err);
-                                errors.quic_errors += 1;
-                            }
-                        }
-                    }
-                    Ok(Err(e)) => {
-                        eprintln!("socket recv_from error: {}", e);
-                        errors.recv_errors += 1;
-                    }
-                    Err(_) => {
-                        quic_conn.on_timeout();
-                    }
-                }
-
-                // Send pending packets
-                loop {
-                    match quic_conn.send(&mut out) {
-                        Ok((write, send_info)) => {
-                            if let Err(e) = socket.send_to(&out[..write], send_info.to).await {
-                                eprintln!("send_to failed: {}", e);
-                                errors.send_errors += 1;
-                            }
-                        }
-                        Err(quiche::Error::Done) => break,
-                        Err(_) => break,
-                    }
-                }
+        loop {
+            if Instant::now() >= deadline {
+                self.pool.mark_failed();
+                return Err("timeout waiting for response".into());
             }
 
-            // Poll for stream events
-            {
-                let pool = &mut self.pool;
-                let quic_conn = pool.quic_conn.as_mut().ok_or("Connection lost")?;
-                let h3_conn = pool.h3_conn.as_mut().ok_or("Connection lost")?;
-
-                if quic_conn.is_closed() {
-                    pool.mark_failed();
-                    premature_close = true;
-                    break;
+            // Check if our stream already resolved (e.g. result delivered in poll_once).
+            match rx.try_recv() {
+                Ok(result) => return result.map_err(|e| e.into()),
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    return Err("response channel closed unexpectedly".into());
                 }
+                Err(oneshot::error::TryRecvError::Empty) => {}
+            }
 
-                loop {
-                    match h3_conn.poll(quic_conn) {
-                        Ok((id, quiche::h3::Event::Headers { list, .. })) => {
-                            if id != stream_id {
-                                continue;
-                            }
-                            for h in list {
-                                let name = String::from_utf8_lossy(h.name());
-                                let value = String::from_utf8_lossy(h.value());
+            if !self.poll_once().await {
+                // Connection died; check if our result was delivered before the death.
+                return Err("connection closed before response completed".into());
+            }
 
-                                if name == ":status"
-                                    && let Ok(code) = value.parse::<u16>()
-                                {
-                                    status_code = Some(code);
-                                }
-
-                                if verbose {
-                                    println!("{name}: {value}");
-                                }
-                            }
-                        }
-                        Ok((id, quiche::h3::Event::Data)) => {
-                            if id != stream_id {
-                                continue;
-                            }
-                            loop {
-                                match h3_conn.recv_body(quic_conn, id, &mut buf) {
-                                    Ok(read) => {
-                                        bytes_received += read;
-                                        if verbose {
-                                            response_body.extend_from_slice(&buf[..read]);
-                                        }
-                                    }
-                                    Err(quiche::h3::Error::Done) => break,
-                                    Err(e) => {
-                                        eprintln!("recv_body error: {:?}", e);
-                                        errors.quic_errors += 1;
-                                        response_done = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        Ok((id, quiche::h3::Event::Finished)) => {
-                            if id == stream_id {
-                                response_done = true;
-                                break;
-                            }
-                        }
-                        Ok((_id, quiche::h3::Event::PriorityUpdate)) => {}
-                        Ok((_id, quiche::h3::Event::GoAway)) => {
-                            pool.mark_failed();
-                            response_done = true;
-                            break;
-                        }
-                        Ok((_id, quiche::h3::Event::Reset(sid))) => {
-                            if sid == stream_id {
-                                eprintln!("Stream reset by peer");
-                                errors.stream_reset_errors += 1;
-                                response_done = true;
-                                break;
-                            }
-                        }
-                        Err(quiche::h3::Error::Done) => break,
-                        Err(e) => {
-                            eprintln!("h3 poll error: {:?}", e);
-                            errors.quic_errors += 1;
-                            break;
-                        }
-                    }
+            // Re-check after poll_once delivered events.
+            match rx.try_recv() {
+                Ok(result) => return result.map_err(|e| e.into()),
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    return Err("response channel closed unexpectedly".into());
                 }
+                Err(oneshot::error::TryRecvError::Empty) => {}
             }
         }
-
-        if start.elapsed() >= Duration::from_secs(constants::network::RESPONSE_TIMEOUT_SECS) && !response_done {
-            self.pool.mark_failed();
-            return Err("timeout waiting for response".into());
-        }
-
-        if premature_close {
-            return Err("connection closed before response completed".into());
-        }
-
-        let status_code = match status_code {
-            Some(code) => code,
-            None => return Err("response completed without :status header".into()),
-        };
-
-        let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
-        let body = if verbose {
-            Some(String::from_utf8_lossy(&response_body).to_string())
-        } else {
-            None
-        };
-
-        Ok(ResponseResult {
-            status_code,
-            bytes_received,
-            errors,
-            latency_ms,
-            body,
-        })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 use clap::Parser;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Instant, Duration};
 use std::collections::HashMap;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::FuturesUnordered;
 
 pub mod client;
 pub mod utils;
@@ -120,71 +119,126 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut status_codes: HashMap<u16, usize> = HashMap::new();
             let mut latencies = Vec::new();
 
-            // Shared counter of requests claimed across all slots in this worker.
-            let dispatched = Arc::new(AtomicUsize::new(0));
-
-            // Each concurrency slot owns a persistent Http3Client so it can reuse
-            // its QUIC connection across many sequential requests. Slots run as
-            // concurrent tasks; FuturesUnordered drives them in parallel.
-            let make_slot = |slot_id: usize| {
-                let server_name = server_name.clone();
-                let authority = authority.clone();
-                let path = path.clone();
-                let success_status = success_status.clone();
-                let dispatched = Arc::clone(&dispatched);
-                let deadline = Arc::clone(&deadline);
-                tokio::spawn(async move {
-                    let mut client = client::h3_client::Http3Client::new(insecure, peer_addr)
-                        .map_err(|e| format!("slot {slot_id} init: {e}"))?;
-                    let mut slot_results = Vec::new();
-
-                    loop {
-                        if Instant::now() >= *deadline {
-                            break;
-                        }
-                        let i = dispatched.fetch_add(1, Ordering::Relaxed);
-                        if i >= requests_per_worker {
-                            break;
-                        }
-                        let result = client
-                            .send_request(&server_name, &authority, &path, verbose)
-                            .await
-                            .map_err(|e| format!("{e}"))?;
-                        let ok = is_success_status(result.status_code, &success_status);
-                        slot_results.push((ok, result));
-                    }
-
-                    Ok::<_, String>(slot_results)
-                })
+            // One Http3Client per worker: all concurrent streams share one QUIC
+            // connection. On connection failure we reconnect and keep going.
+            let mut h3 = match client::h3_client::Http3Client::new(insecure, peer_addr) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("Worker {worker_id}: init failed: {e}");
+                    return (0, 1, ErrorStats::default(), HashMap::new(), Vec::new());
+                }
             };
 
-            // Launch one persistent slot per concurrency unit.
-            let mut in_flight: FuturesUnordered<_> = FuturesUnordered::new();
-            for slot_id in 0..concurrency {
-                in_flight.push(make_slot(slot_id));
+            // Establish the connection before dispatching any streams.
+            if let Err(e) = h3.ensure_connected(&server_name).await {
+                eprintln!("Worker {worker_id}: connect failed: {e}");
+                return (0, 1, ErrorStats::default(), HashMap::new(), Vec::new());
             }
 
-            // Collect results as slots finish.
-            while let Some(join_result) = in_flight.next().await {
-                match join_result {
-                    Ok(Ok(slot_results)) => {
-                        for (ok, result) in slot_results {
-                            *status_codes.entry(result.status_code).or_insert(0) += 1;
-                            if ok { success += 1; } else { fail += 1; }
-                            total_errors.send_errors += result.errors.send_errors;
-                            total_errors.recv_errors += result.errors.recv_errors;
-                            total_errors.quic_errors += result.errors.quic_errors;
-                            total_errors.stream_reset_errors += result.errors.stream_reset_errors;
-                            latencies.push(result.latency_ms);
-                        }
-                    }
-                    Ok(Err(e)) => {
-                        eprintln!("Worker {worker_id}: slot failed: {e}");
-                        fail += 1;
+            let mut dispatched: usize = 0;
+
+            // Receivers for the currently in-flight streams.
+            // We use FuturesUnordered to await them concurrently while also
+            // driving the shared poll loop.
+            let mut pending: FuturesUnordered<
+                tokio::task::JoinHandle<(bool, Result<client::ResponseResult, String>)>
+            > = FuturesUnordered::new();
+
+            // Seed up to `concurrency` streams.
+            for _ in 0..concurrency {
+                if Instant::now() >= *deadline || dispatched >= requests_per_worker { break; }
+                dispatched += 1;
+
+                match h3.dispatch(&authority, &path, verbose) {
+                    Ok((_sid, rx)) => {
+                        let success_status = success_status.clone();
+                        pending.push(tokio::spawn(async move {
+                            let result = rx.await
+                                .unwrap_or_else(|_| Err("channel closed".into()));
+                            let ok = result.as_ref()
+                                .map(|r| is_success_status(r.status_code, &success_status))
+                                .unwrap_or(false);
+                            (ok, result)
+                        }));
                     }
                     Err(e) => {
-                        eprintln!("Worker {worker_id}: slot panicked: {e}");
+                        eprintln!("Worker {worker_id}: dispatch failed: {e}");
                         fail += 1;
+                    }
+                }
+            }
+
+            // Drive the connection and collect results. We select between the
+            // QUIC poll loop and the first completed receiver so neither starves
+            // the other. poll_once() has an internal timeout so it yields
+            // promptly even when no packets arrive.
+            use futures::stream::StreamExt as _;
+            loop {
+                if pending.is_empty() {
+                    break;
+                }
+
+                tokio::select! {
+                    // Drive QUIC I/O and H3 event dispatch.
+                    alive = h3.poll_once(), if h3.has_in_flight() => {
+                        if !alive {
+                            let _ = h3.ensure_connected(&server_name).await;
+                        }
+                    }
+                    // A stream receiver resolved.
+                    Some(join_result) = pending.next() => {
+                        let (ok, result) = match join_result {
+                            Ok(pair) => pair,
+                            Err(e) => {
+                                eprintln!("Worker {worker_id}: task panicked: {e}");
+                                fail += 1;
+                                continue;
+                            }
+                        };
+                        match result {
+                            Ok(r) => {
+                                *status_codes.entry(r.status_code).or_insert(0) += 1;
+                                if ok { success += 1; } else { fail += 1; }
+                                total_errors.send_errors += r.errors.send_errors;
+                                total_errors.recv_errors += r.errors.recv_errors;
+                                total_errors.quic_errors += r.errors.quic_errors;
+                                total_errors.stream_reset_errors += r.errors.stream_reset_errors;
+                                latencies.push(r.latency_ms);
+                            }
+                            Err(e) => {
+                                eprintln!("Worker {worker_id}: request failed: {e}");
+                                fail += 1;
+                            }
+                        }
+
+                        // Backfill: keep concurrency slots full.
+                        if Instant::now() < *deadline && dispatched < requests_per_worker {
+                            dispatched += 1;
+                            if !h3.is_connected() {
+                                if let Err(e) = h3.ensure_connected(&server_name).await {
+                                    eprintln!("Worker {worker_id}: reconnect failed: {e}");
+                                    fail += 1;
+                                    continue;
+                                }
+                            }
+                            match h3.dispatch(&authority, &path, verbose) {
+                                Ok((_sid, rx)) => {
+                                    let success_status = success_status.clone();
+                                    pending.push(tokio::spawn(async move {
+                                        let result = rx.await
+                                            .unwrap_or_else(|_| Err("channel closed".into()));
+                                        let ok = result.as_ref()
+                                            .map(|r| is_success_status(r.status_code, &success_status))
+                                            .unwrap_or(false);
+                                        (ok, result)
+                                    }));
+                                }
+                                Err(e) => {
+                                    eprintln!("Worker {worker_id}: dispatch failed: {e}");
+                                    fail += 1;
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,11 +180,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 tokio::select! {
                     // Drive QUIC I/O and H3 event dispatch.
-                    alive = h3.poll_once(), if h3.has_in_flight() => {
-                        if !alive {
-                            let _ = h3.ensure_connected(&server_name).await;
-                        }
-                    }
+                    // When the connection dies, poll_once drains any in-flight
+                    // streams with a "connection replaced" error so their tasks
+                    // complete and flow through pending.next() below.
+                    _alive = h3.poll_once(), if h3.has_in_flight() => {}
                     // A stream receiver resolved.
                     Some(join_result) = pending.next() => {
                         let (ok, result) = match join_result {
@@ -204,6 +203,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 total_errors.quic_errors += r.errors.quic_errors;
                                 total_errors.stream_reset_errors += r.errors.stream_reset_errors;
                                 latencies.push(r.latency_ms);
+                            }
+                            Err(ref e) if e.contains("connection replaced") => {
+                                // Stream was killed when the connection closed mid-flight.
+                                // Undo the dispatch count so the backfill below re-queues it.
+                                dispatched = dispatched.saturating_sub(1);
                             }
                             Err(e) => {
                                 eprintln!("Worker {worker_id}: request failed: {e}");


### PR DESCRIPTION
Merger After PR #28 

## Summary

- `poll_once` now drains `in_flight` with a retryable `"connection replaced"` error when the QUIC connection closes, so pending tasks unblock immediately instead of hanging
- `poll_once` checks `is_closed()` *after* `recv()` (not before), ensuring buffered H3 `Finished` events are delivered even when the connection is in the process of closing
- `recv_from` timeout is now capped at the configured poll constant — quiche's retransmission timer (up to 500ms+) was stalling the I/O loop between packets
- `main.rs` removes `ensure_connected` from the `poll_once` arm; reconnection now happens exclusively in the `pending.next()` backfill arm, keeping the flow linear
- Streams killed by a mid-flight connection close are automatically retried (dispatched count decremented) rather than counted as failures

## Motivation

Google and some other servers close the QUIC connection immediately after each response.
Before this fix, vex would dispatch a stream onto the dying connection, fail to deliver
its `Finished` event, stall in a multi-second `recv_from` loop, and report the request
as a failure. All 20 requests to `google.com` would fail.

After this fix:

```sh
-n 1000  --workers 10  -c 100  →  1000/1000 success, 907 req/s
-n 10000 --workers 100 -c 1000 →  10000/10000 success, 1160 req/s
```