### PR TITLE
feat(metrics): configurable timeouts, deadline enforcement, and connection observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,94 +196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,7 +578,6 @@ name = "vex"
 version = "0.1.0"
 dependencies = [
  "clap",
- "futures",
  "http",
  "quiche",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ quiche = "0.24.6"
 http = "1.3.1"
 rand = "0.8"
 clap = { version = "4.0", features = ["derive"] }
-futures = "0.3"

--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -101,6 +101,7 @@ impl Http3Client {
     pub async fn ensure_connected(
         &mut self,
         server_name: &str,
+        connect_timeout: Duration,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if self.pool.is_usable() {
             return Ok(());
@@ -130,8 +131,7 @@ impl Http3Client {
 
         let mut out = [0u8; constants::network::BUFFER_SIZE];
         let mut buf = [0u8; constants::network::BUFFER_SIZE];
-        let handshake_deadline =
-            Instant::now() + Duration::from_secs(constants::network::HANDSHAKE_TIMEOUT_SECS);
+        let handshake_deadline = Instant::now() + connect_timeout;
         let mut h3_conn: Option<quiche::h3::Connection> = None;
 
         loop {

--- a/src/client/h3_client.rs
+++ b/src/client/h3_client.rs
@@ -98,13 +98,16 @@ impl Http3Client {
         Ok(config)
     }
 
+    /// Connect if not already connected. Returns the handshake latency in
+    /// milliseconds on a new connection, or `None` if the pool was already
+    /// usable (no handshake was performed).
     pub async fn ensure_connected(
         &mut self,
         server_name: &str,
         connect_timeout: Duration,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<Option<f64>, Box<dyn std::error::Error>> {
         if self.pool.is_usable() {
-            return Ok(());
+            return Ok(None);
         }
 
         // poll_once drains in_flight before returning false, so by the time
@@ -131,7 +134,8 @@ impl Http3Client {
 
         let mut out = [0u8; constants::network::BUFFER_SIZE];
         let mut buf = [0u8; constants::network::BUFFER_SIZE];
-        let handshake_deadline = Instant::now() + connect_timeout;
+        let handshake_start = Instant::now();
+        let handshake_deadline = handshake_start + connect_timeout;
         let mut h3_conn: Option<quiche::h3::Connection> = None;
 
         loop {
@@ -193,6 +197,8 @@ impl Http3Client {
             }
         }
 
+        let handshake_ms = handshake_start.elapsed().as_secs_f64() * 1000.0;
+
         self.pool.quic_conn = Some(quic_conn);
         self.pool.h3_conn = h3_conn;
         self.pool.socket = Some(Arc::new(socket));
@@ -200,7 +206,7 @@ impl Http3Client {
         self.pool.peer_addr = Some(peer_addr);
         self.pool.failed = false;
 
-        Ok(())
+        Ok(Some(handshake_ms))
     }
 
     // Dispatch one HTTP/3 stream and return a receiver that resolves when the

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use futures::stream::FuturesUnordered;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -92,11 +91,12 @@ fn requests_for_worker(total_requests: usize, workers: usize, worker_id: usize) 
 }
 
 fn spawn_stream_waiter(
+    join_set: &mut tokio::task::JoinSet<(u64, PendingOutcome)>,
     stream_id: u64,
     rx: oneshot::Receiver<Result<ResponseResult, String>>,
     request_timeout: Duration,
-) -> tokio::task::JoinHandle<(u64, PendingOutcome)> {
-    tokio::spawn(async move {
+) {
+    join_set.spawn(async move {
         match tokio::time::timeout(request_timeout, rx).await {
             Ok(Ok(result)) => (stream_id, PendingOutcome::Completed(result)),
             Ok(Err(_)) => (
@@ -105,7 +105,7 @@ fn spawn_stream_waiter(
             ),
             Err(_) => (stream_id, PendingOutcome::TimedOut),
         }
-    })
+    });
 }
 
 async fn dispatch_with_retry(
@@ -271,11 +271,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             let mut dispatched = 0usize;
-            let mut pending: FuturesUnordered<tokio::task::JoinHandle<(u64, PendingOutcome)>> =
-                FuturesUnordered::new();
+            let mut pending: tokio::task::JoinSet<(u64, PendingOutcome)> =
+                tokio::task::JoinSet::new();
+            let deadline_instant = tokio::time::Instant::from_std(*deadline);
 
-            use futures::stream::StreamExt as _;
-            loop {
+            'worker: loop {
                 while pending.len() < concurrency
                     && Instant::now() < *deadline
                     && dispatched < requests_per_worker
@@ -292,7 +292,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .await
                     {
                         Ok((stream_id, rx)) => {
-                            pending.push(spawn_stream_waiter(stream_id, rx, request_timeout));
+                            spawn_stream_waiter(&mut pending, stream_id, rx, request_timeout);
                         }
                         Err(e) => {
                             eprintln!("Worker {worker_id}: {e}");
@@ -309,10 +309,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
 
                 tokio::select! {
+                    _ = tokio::time::sleep_until(deadline_instant) => {
+                        // Hard-cancel all in-flight stream waiters so they don't
+                        // continue running detached after the duration deadline.
+                        pending.abort_all();
+                        duration_limited = true;
+                        break 'worker;
+                    }
                     _ = h3.poll_once(), if h3.has_in_flight() => {}
-                    Some(join_result) = pending.next() => {
+                    Some(join_result) = pending.join_next() => {
                         let (stream_id, outcome) = match join_result {
                             Ok(pair) => pair,
+                            Err(e) if e.is_cancelled() => continue,
                             Err(e) => {
                                 eprintln!("Worker {worker_id}: task panicked: {e}");
                                 fail += 1;
@@ -412,6 +420,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         CompletionReason::AllRequestsCompleted
     };
 
+    // For throughput, use the configured duration as the denominator when
+    // duration-limited so that in-flight work draining past the deadline
+    // does not deflate the reported req/s.
+    let throughput_window = if hit_duration_limit {
+        cli.duration as f64
+    } else {
+        elapsed
+    };
+
     println!("\nLoad test completed:");
     println!("  Total time: {:.2}s", elapsed);
     println!("  Total requests: {}", total_requests);
@@ -425,8 +442,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     println!(
         "  Requests/sec: {:.2}",
-        if elapsed > 0.0 {
-            total_requests as f64 / elapsed
+        if throughput_window > 0.0 {
+            total_requests as f64 / throughput_window
         } else {
             0.0
         }
@@ -435,8 +452,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match completion_reason {
         CompletionReason::DurationLimitReached => {
             println!(
-                "  Completion reason: Duration limit ({:.0}s) reached",
-                cli.duration
+                "  Completion reason: Duration limit ({:.0}s) reached (actual: {:.2}s)",
+                cli.duration, elapsed
             );
         }
         CompletionReason::AllRequestsCompleted => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,14 +443,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         CompletionReason::AllRequestsCompleted
     };
 
-    // For throughput, use the configured duration as the denominator when
-    // duration-limited so that in-flight work draining past the deadline
-    // does not deflate the reported req/s.
-    let throughput_window = if hit_duration_limit {
-        cli.duration as f64
-    } else {
-        elapsed
-    };
+    let duration_window = cli.duration as f64;
 
     println!("\nLoad test completed:");
     println!("  Total time: {:.2}s", elapsed);
@@ -463,14 +456,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             timed_out_requests, cli.request_timeout_ms
         );
     }
-    println!(
-        "  Requests/sec: {:.2}",
-        if throughput_window > 0.0 {
-            total_requests as f64 / throughput_window
-        } else {
-            0.0
-        }
-    );
+    if hit_duration_limit {
+        // In-duration: requests completed ÷ configured window (excludes post-deadline tail).
+        // End-to-end: requests completed ÷ actual wall-clock time (includes post-deadline tail).
+        println!(
+            "  Req/s (in-duration):  {:.2}",
+            if duration_window > 0.0 { total_requests as f64 / duration_window } else { 0.0 }
+        );
+        println!(
+            "  Req/s (end-to-end):   {:.2}",
+            if elapsed > 0.0 { total_requests as f64 / elapsed } else { 0.0 }
+        );
+    } else {
+        println!(
+            "  Requests/sec: {:.2}",
+            if elapsed > 0.0 { total_requests as f64 / elapsed } else { 0.0 }
+        );
+    }
 
     match completion_reason {
         CompletionReason::DurationLimitReached => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,9 @@ struct Cli {
         help = "Connection handshake timeout in milliseconds"
     )]
     connect_timeout_ms: u64,
+
+    #[arg(long, default_value = "false", help = "Emit results as JSON to stdout")]
+    json: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -108,6 +111,8 @@ fn spawn_stream_waiter(
     });
 }
 
+/// Returns the dispatched (stream_id, rx) pair plus any handshake latency
+/// recorded during reconnects (None if no reconnect was needed).
 async fn dispatch_with_retry(
     h3: &mut client::h3_client::Http3Client,
     server_name: &str,
@@ -115,16 +120,18 @@ async fn dispatch_with_retry(
     path: &str,
     verbose: bool,
     connect_timeout: Duration,
-) -> Result<(u64, oneshot::Receiver<Result<ResponseResult, String>>), String> {
+) -> Result<(u64, oneshot::Receiver<Result<ResponseResult, String>>, Option<f64>), String> {
+    let mut reconnect_hs_ms: Option<f64> = None;
     for attempt in 1..=MAX_DISPATCH_ATTEMPTS {
         if !h3.is_connected() {
-            h3.ensure_connected(server_name, connect_timeout)
-                .await
-                .map_err(|e| format!("reconnect failed: {e}"))?;
+            match h3.ensure_connected(server_name, connect_timeout).await {
+                Ok(hs) => reconnect_hs_ms = hs,
+                Err(e) => return Err(format!("reconnect failed: {e}")),
+            }
         }
 
         match h3.dispatch(authority, path, verbose) {
-            Ok(pair) => return Ok(pair),
+            Ok((sid, rx)) => return Ok((sid, rx, reconnect_hs_ms)),
             Err(err) if err.is_retryable() && attempt < MAX_DISPATCH_ATTEMPTS => {
                 let _ = h3.poll_once().await;
                 tokio::time::sleep(Duration::from_millis(DISPATCH_RETRY_BACKOFF_MS)).await;
@@ -218,6 +225,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut worker_failures = 0;
     let mut success_latencies: Vec<f64> = Vec::new();
     let mut failure_latencies: Vec<f64> = Vec::new();
+    let mut conn_attempts = 0usize;
+    let mut conn_failures = 0usize;
+    let mut handshake_latencies: Vec<f64> = Vec::new();
+    let mut peak_concurrency = 0usize;
     let mut hit_duration_limit = false;
 
     let mut handles = vec![];
@@ -243,18 +254,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut status_codes: HashMap<u16, usize> = HashMap::new();
             let mut success_lats: Vec<f64> = Vec::new();
             let mut failure_lats: Vec<f64> = Vec::new();
+            let mut conn_attempts = 0usize;
+            let mut conn_failures = 0usize;
+            let mut handshake_lats: Vec<f64> = Vec::new();
+            let mut peak_concurrency = 0usize;
             let mut duration_limited = false;
+
+            macro_rules! empty_return {
+                ($fail:expr) => {
+                    return (
+                        0, $fail, 0,
+                        ErrorStats::default(), HashMap::new(),
+                        Vec::new(), Vec::new(),
+                        conn_attempts, conn_failures, handshake_lats,
+                        0usize, false,
+                    )
+                };
+            }
 
             if requests_per_worker == 0 {
                 return (
-                    success,
-                    fail,
-                    timed_out,
-                    total_errors,
-                    status_codes,
-                    success_lats,
-                    failure_lats,
-                    duration_limited,
+                    success, fail, timed_out, total_errors, status_codes,
+                    success_lats, failure_lats,
+                    conn_attempts, conn_failures, handshake_lats,
+                    peak_concurrency, duration_limited,
                 );
             }
 
@@ -262,31 +285,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!("Worker {worker_id}: init failed: {e}");
-                    return (
-                        0,
-                        requests_per_worker,
-                        0,
-                        ErrorStats::default(),
-                        HashMap::new(),
-                        Vec::new(),
-                        Vec::new(),
-                        false,
-                    );
+                    empty_return!(requests_per_worker);
                 }
             };
 
-            if let Err(e) = h3.ensure_connected(&server_name, connect_timeout).await {
-                eprintln!("Worker {worker_id}: connect failed: {e}");
-                return (
-                    0,
-                    requests_per_worker,
-                    0,
-                    ErrorStats::default(),
-                    HashMap::new(),
-                    Vec::new(),
-                    Vec::new(),
-                    false,
-                );
+            conn_attempts += 1;
+            match h3.ensure_connected(&server_name, connect_timeout).await {
+                Ok(Some(ms)) => handshake_lats.push(ms),
+                Ok(None) => {}
+                Err(e) => {
+                    eprintln!("Worker {worker_id}: connect failed: {e}");
+                    conn_failures += 1;
+                    empty_return!(requests_per_worker);
+                }
             }
 
             let mut dispatched = 0usize;
@@ -310,11 +321,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await
                     {
-                        Ok((stream_id, rx)) => {
+                        Ok((stream_id, rx, hs_ms)) => {
+                            if let Some(ms) = hs_ms {
+                                conn_attempts += 1;
+                                handshake_lats.push(ms);
+                            }
                             spawn_stream_waiter(&mut pending, stream_id, rx, request_timeout);
+                            let c = pending.len();
+                            if c > peak_concurrency {
+                                peak_concurrency = c;
+                            }
                         }
                         Err(e) => {
                             eprintln!("Worker {worker_id}: {e}");
+                            if e.contains("reconnect failed") {
+                                conn_attempts += 1;
+                                conn_failures += 1;
+                            }
                             fail += 1;
                         }
                     }
@@ -385,14 +408,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             (
-                success,
-                fail,
-                timed_out,
-                total_errors,
-                status_codes,
-                success_lats,
-                failure_lats,
-                duration_limited,
+                success, fail, timed_out, total_errors, status_codes,
+                success_lats, failure_lats,
+                conn_attempts, conn_failures, handshake_lats,
+                peak_concurrency, duration_limited,
             )
         });
 
@@ -401,7 +420,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for (worker_id, handle) in handles.into_iter().enumerate() {
         match handle.await {
-            Ok((s, f, t, errors, status_codes, s_lats, f_lats, duration_limited)) => {
+            Ok((s, f, t, errors, status_codes, s_lats, f_lats, ca, cf, hs_lats, peak, duration_limited)) => {
                 total_requests += s + f;
                 successful_requests += s;
                 failed_requests += f;
@@ -411,6 +430,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 total_errors.quic_errors += errors.quic_errors;
                 total_errors.stream_reset_errors += errors.stream_reset_errors;
                 hit_duration_limit |= duration_limited;
+                conn_attempts += ca;
+                conn_failures += cf;
+                handshake_latencies.extend(hs_lats);
+                if peak > peak_concurrency {
+                    peak_concurrency = peak;
+                }
 
                 for (code, count) in status_codes {
                     *status_code_counts.entry(code).or_insert(0) += count;
@@ -530,14 +555,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    if !success_latencies.is_empty() {
-        success_latencies.sort_by(|a, b| a.total_cmp(b));
-        print_latency_block("Latency (successful requests, ms)", &success_latencies);
-    }
+    success_latencies.sort_by(|a, b| a.total_cmp(b));
+    failure_latencies.sort_by(|a, b| a.total_cmp(b));
+    handshake_latencies.sort_by(|a, b| a.total_cmp(b));
 
-    if !failure_latencies.is_empty() {
-        failure_latencies.sort_by(|a, b| a.total_cmp(b));
-        print_latency_block("Latency (failed requests, ms)", &failure_latencies);
+    let rps_in_duration = if duration_window > 0.0 { total_requests as f64 / duration_window } else { 0.0 };
+    let rps_end_to_end  = if elapsed > 0.0           { total_requests as f64 / elapsed }          else { 0.0 };
+
+    if cli.json {
+        print_json(
+            &cli, elapsed, total_requests, successful_requests, failed_requests,
+            timed_out_requests, rps_in_duration, rps_end_to_end, hit_duration_limit,
+            &total_errors, &status_code_counts,
+            &success_latencies, &failure_latencies,
+            conn_attempts, conn_failures, &handshake_latencies, peak_concurrency,
+        );
+    } else {
+        if !success_latencies.is_empty() {
+            print_latency_block("Latency (successful requests, ms)", &success_latencies);
+        }
+        if !failure_latencies.is_empty() {
+            print_latency_block("Latency (failed requests, ms)", &failure_latencies);
+        }
+
+        println!("\nConnection diagnostics:");
+        println!("  Connection attempts:  {}", conn_attempts);
+        println!("  Connection failures:  {}", conn_failures);
+        println!("  Peak stream concurrency: {}", peak_concurrency);
+        if !handshake_latencies.is_empty() {
+            print_latency_block("Handshake latency (ms)", &handshake_latencies);
+        }
     }
 
     if worker_failures > 0 {
@@ -564,6 +611,109 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_json(
+    cli: &Cli,
+    elapsed: f64,
+    total_requests: usize,
+    successful_requests: usize,
+    failed_requests: usize,
+    timed_out_requests: usize,
+    rps_in_duration: f64,
+    rps_end_to_end: f64,
+    hit_duration_limit: bool,
+    errors: &ErrorStats,
+    status_codes: &HashMap<u16, usize>,
+    success_lats: &[f64],
+    failure_lats: &[f64],
+    conn_attempts: usize,
+    conn_failures: usize,
+    handshake_lats: &[f64],
+    peak_concurrency: usize,
+) {
+    let lat_obj = |lats: &[f64]| -> String {
+        if lats.is_empty() {
+            return "null".into();
+        }
+        let min = lats[0];
+        let max = lats[lats.len() - 1];
+        let avg = lats.iter().sum::<f64>() / lats.len() as f64;
+        format!(
+            "{{\"min\":{min:.3},\"max\":{max:.3},\"avg\":{avg:.3},\
+             \"p50\":{p50:.3},\"p90\":{p90:.3},\"p95\":{p95:.3},\"p99\":{p99:.3}}}",
+            p50 = percentile(lats, 50.0),
+            p90 = percentile(lats, 90.0),
+            p95 = percentile(lats, 95.0),
+            p99 = percentile(lats, 99.0),
+        )
+    };
+
+    let status_entries: Vec<String> = {
+        let mut sorted: Vec<_> = status_codes.iter().collect();
+        sorted.sort_by_key(|&(k, _)| k);
+        sorted.iter().map(|(k, v)| format!("\"{k}\":{v}")).collect()
+    };
+
+    println!(
+        concat!(
+            "{{\n",
+            "  \"target\": \"{target}\",\n",
+            "  \"workers\": {workers},\n",
+            "  \"concurrency\": {concurrency},\n",
+            "  \"total_time_s\": {elapsed:.3},\n",
+            "  \"duration_limited\": {dur_lim},\n",
+            "  \"requests\": {{\n",
+            "    \"total\": {total},\n",
+            "    \"successful\": {succ},\n",
+            "    \"failed\": {fail},\n",
+            "    \"timed_out\": {timed_out}\n",
+            "  }},\n",
+            "  \"throughput\": {{\n",
+            "    \"rps_in_duration\": {rps_in:.3},\n",
+            "    \"rps_end_to_end\": {rps_e2e:.3}\n",
+            "  }},\n",
+            "  \"errors\": {{\n",
+            "    \"send\": {send_err},\n",
+            "    \"recv\": {recv_err},\n",
+            "    \"quic\": {quic_err},\n",
+            "    \"stream_reset\": {reset_err}\n",
+            "  }},\n",
+            "  \"status_codes\": {{{status}}},\n",
+            "  \"latency_success_ms\": {lat_succ},\n",
+            "  \"latency_failure_ms\": {lat_fail},\n",
+            "  \"connections\": {{\n",
+            "    \"attempts\": {conn_att},\n",
+            "    \"failures\": {conn_fail},\n",
+            "    \"peak_stream_concurrency\": {peak},\n",
+            "    \"handshake_latency_ms\": {lat_hs}\n",
+            "  }}\n",
+            "}}"
+        ),
+        target      = cli.target,
+        workers     = cli.workers,
+        concurrency = cli.concurrency,
+        elapsed     = elapsed,
+        dur_lim     = hit_duration_limit,
+        total       = total_requests,
+        succ        = successful_requests,
+        fail        = failed_requests,
+        timed_out   = timed_out_requests,
+        rps_in      = rps_in_duration,
+        rps_e2e     = rps_end_to_end,
+        send_err    = errors.send_errors,
+        recv_err    = errors.recv_errors,
+        quic_err    = errors.quic_errors,
+        reset_err   = errors.stream_reset_errors,
+        status      = status_entries.join(","),
+        lat_succ    = lat_obj(success_lats),
+        lat_fail    = lat_obj(failure_lats),
+        conn_att    = conn_attempts,
+        conn_fail   = conn_failures,
+        peak        = peak_concurrency,
+        lat_hs      = lat_obj(handshake_lats),
+    );
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,20 @@ struct Cli {
         help = "Number of concurrent in-flight requests per worker"
     )]
     concurrency: usize,
+
+    #[arg(
+        long,
+        default_value = "5000",
+        help = "Per-request response timeout in milliseconds"
+    )]
+    request_timeout_ms: u64,
+
+    #[arg(
+        long,
+        default_value = "5000",
+        help = "Connection handshake timeout in milliseconds"
+    )]
+    connect_timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,14 +94,10 @@ fn requests_for_worker(total_requests: usize, workers: usize, worker_id: usize) 
 fn spawn_stream_waiter(
     stream_id: u64,
     rx: oneshot::Receiver<Result<ResponseResult, String>>,
+    request_timeout: Duration,
 ) -> tokio::task::JoinHandle<(u64, PendingOutcome)> {
     tokio::spawn(async move {
-        match tokio::time::timeout(
-            Duration::from_secs(client::constants::network::RESPONSE_TIMEOUT_SECS),
-            rx,
-        )
-        .await
-        {
+        match tokio::time::timeout(request_timeout, rx).await {
             Ok(Ok(result)) => (stream_id, PendingOutcome::Completed(result)),
             Ok(Err(_)) => (
                 stream_id,
@@ -104,10 +114,11 @@ async fn dispatch_with_retry(
     authority: &str,
     path: &str,
     verbose: bool,
+    connect_timeout: Duration,
 ) -> Result<(u64, oneshot::Receiver<Result<ResponseResult, String>>), String> {
     for attempt in 1..=MAX_DISPATCH_ATTEMPTS {
         if !h3.is_connected() {
-            h3.ensure_connected(server_name)
+            h3.ensure_connected(server_name, connect_timeout)
                 .await
                 .map_err(|e| format!("reconnect failed: {e}"))?;
         }
@@ -174,6 +185,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Concurrency per worker: {}", cli.concurrency);
     println!("  Total requests: {}", cli.requests);
     println!("  Duration: {}s", cli.duration);
+    println!("  Request timeout: {}ms", cli.request_timeout_ms);
+    println!("  Connect timeout: {}ms", cli.connect_timeout_ms);
     println!("  Insecure: {}", cli.insecure);
     if cli.verbose {
         println!("  Verbose: enabled");
@@ -185,6 +198,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut total_requests = 0;
     let mut successful_requests = 0;
     let mut failed_requests = 0;
+    let mut timed_out_requests = 0usize;
     let mut total_errors = ErrorStats::default();
     let mut status_code_counts: HashMap<u16, usize> = HashMap::new();
     let mut worker_failures = 0;
@@ -202,11 +216,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let success_status = cli.success_status.clone();
         let requests_per_worker = requests_for_worker(cli.requests, cli.workers, worker_id);
         let concurrency = cli.concurrency;
+        let request_timeout = Duration::from_millis(cli.request_timeout_ms);
+        let connect_timeout = Duration::from_millis(cli.connect_timeout_ms);
         let deadline = Arc::clone(&deadline);
 
         let handle = tokio::spawn(async move {
             let mut success = 0usize;
             let mut fail = 0usize;
+            let mut timed_out = 0usize;
             let mut total_errors = ErrorStats::default();
             let mut status_codes: HashMap<u16, usize> = HashMap::new();
             let mut latencies = Vec::new();
@@ -216,6 +233,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 return (
                     success,
                     fail,
+                    timed_out,
                     total_errors,
                     status_codes,
                     latencies,
@@ -230,6 +248,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     return (
                         0,
                         requests_per_worker,
+                        0,
                         ErrorStats::default(),
                         HashMap::new(),
                         Vec::new(),
@@ -238,11 +257,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
 
-            if let Err(e) = h3.ensure_connected(&server_name).await {
+            if let Err(e) = h3.ensure_connected(&server_name, connect_timeout).await {
                 eprintln!("Worker {worker_id}: connect failed: {e}");
                 return (
                     0,
                     requests_per_worker,
+                    0,
                     ErrorStats::default(),
                     HashMap::new(),
                     Vec::new(),
@@ -261,11 +281,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     && dispatched < requests_per_worker
                 {
                     dispatched += 1;
-                    match dispatch_with_retry(&mut h3, &server_name, &authority, &path, verbose)
-                        .await
+                    match dispatch_with_retry(
+                        &mut h3,
+                        &server_name,
+                        &authority,
+                        &path,
+                        verbose,
+                        connect_timeout,
+                    )
+                    .await
                     {
                         Ok((stream_id, rx)) => {
-                            pending.push(spawn_stream_waiter(stream_id, rx));
+                            pending.push(spawn_stream_waiter(stream_id, rx, request_timeout));
                         }
                         Err(e) => {
                             eprintln!("Worker {worker_id}: {e}");
@@ -296,6 +323,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         match outcome {
                             PendingOutcome::TimedOut => {
                                 h3.abandon_stream(stream_id);
+                                timed_out += 1;
                                 fail += 1;
                             }
                             PendingOutcome::Completed(result) => {
@@ -330,6 +358,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             (
                 success,
                 fail,
+                timed_out,
                 total_errors,
                 status_codes,
                 latencies,
@@ -342,10 +371,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for (worker_id, handle) in handles.into_iter().enumerate() {
         match handle.await {
-            Ok((s, f, errors, status_codes, latencies, duration_limited)) => {
+            Ok((s, f, t, errors, status_codes, latencies, duration_limited)) => {
                 total_requests += s + f;
                 successful_requests += s;
                 failed_requests += f;
+                timed_out_requests += t;
                 total_errors.send_errors += errors.send_errors;
                 total_errors.recv_errors += errors.recv_errors;
                 total_errors.quic_errors += errors.quic_errors;
@@ -387,6 +417,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Total requests: {}", total_requests);
     println!("  Successful requests: {}", successful_requests);
     println!("  Failed requests: {}", failed_requests);
+    if timed_out_requests > 0 {
+        println!(
+            "  Timed out requests: {} (>{}ms)",
+            timed_out_requests, cli.request_timeout_ms
+        );
+    }
     println!(
         "  Requests/sec: {:.2}",
         if elapsed > 0.0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,20 @@ async fn dispatch_with_retry(
     Err("dispatch failed unexpectedly".into())
 }
 
+fn print_latency_block(label: &str, sorted: &[f64]) {
+    let min = sorted[0];
+    let max = sorted[sorted.len() - 1];
+    let avg = sorted.iter().sum::<f64>() / sorted.len() as f64;
+    println!("\n{label}:");
+    println!("  Min:  {:.2}", min);
+    println!("  Max:  {:.2}", max);
+    println!("  Avg:  {:.2}", avg);
+    println!("  p50:  {:.2}", percentile(sorted, 50.0));
+    println!("  p90:  {:.2}", percentile(sorted, 90.0));
+    println!("  p95:  {:.2}", percentile(sorted, 95.0));
+    println!("  p99:  {:.2}", percentile(sorted, 99.0));
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
@@ -202,7 +216,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut total_errors = ErrorStats::default();
     let mut status_code_counts: HashMap<u16, usize> = HashMap::new();
     let mut worker_failures = 0;
-    let mut all_latencies = Vec::new();
+    let mut success_latencies: Vec<f64> = Vec::new();
+    let mut failure_latencies: Vec<f64> = Vec::new();
     let mut hit_duration_limit = false;
 
     let mut handles = vec![];
@@ -226,7 +241,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut timed_out = 0usize;
             let mut total_errors = ErrorStats::default();
             let mut status_codes: HashMap<u16, usize> = HashMap::new();
-            let mut latencies = Vec::new();
+            let mut success_lats: Vec<f64> = Vec::new();
+            let mut failure_lats: Vec<f64> = Vec::new();
             let mut duration_limited = false;
 
             if requests_per_worker == 0 {
@@ -236,7 +252,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     timed_out,
                     total_errors,
                     status_codes,
-                    latencies,
+                    success_lats,
+                    failure_lats,
                     duration_limited,
                 );
             }
@@ -252,6 +269,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         ErrorStats::default(),
                         HashMap::new(),
                         Vec::new(),
+                        Vec::new(),
                         false,
                     );
                 }
@@ -265,6 +283,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     0,
                     ErrorStats::default(),
                     HashMap::new(),
+                    Vec::new(),
                     Vec::new(),
                     false,
                 );
@@ -333,21 +352,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 h3.abandon_stream(stream_id);
                                 timed_out += 1;
                                 fail += 1;
+                                failure_lats.push(request_timeout.as_secs_f64() * 1000.0);
                             }
                             PendingOutcome::Completed(result) => {
                                 match result {
                                     Ok(r) => {
                                         *status_codes.entry(r.status_code).or_insert(0) += 1;
-                                        if is_success_status(r.status_code, &success_status) {
-                                            success += 1;
-                                        } else {
-                                            fail += 1;
-                                        }
                                         total_errors.send_errors += r.errors.send_errors;
                                         total_errors.recv_errors += r.errors.recv_errors;
                                         total_errors.quic_errors += r.errors.quic_errors;
                                         total_errors.stream_reset_errors += r.errors.stream_reset_errors;
-                                        latencies.push(r.latency_ms);
+                                        if is_success_status(r.status_code, &success_status) {
+                                            success += 1;
+                                            success_lats.push(r.latency_ms);
+                                        } else {
+                                            fail += 1;
+                                            failure_lats.push(r.latency_ms);
+                                        }
                                     }
                                     Err(ref e) if e.contains("connection replaced") => {
                                         dispatched = dispatched.saturating_sub(1);
@@ -369,7 +390,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 timed_out,
                 total_errors,
                 status_codes,
-                latencies,
+                success_lats,
+                failure_lats,
                 duration_limited,
             )
         });
@@ -379,7 +401,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for (worker_id, handle) in handles.into_iter().enumerate() {
         match handle.await {
-            Ok((s, f, t, errors, status_codes, latencies, duration_limited)) => {
+            Ok((s, f, t, errors, status_codes, s_lats, f_lats, duration_limited)) => {
                 total_requests += s + f;
                 successful_requests += s;
                 failed_requests += f;
@@ -394,7 +416,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     *status_code_counts.entry(code).or_insert(0) += count;
                 }
 
-                all_latencies.extend(latencies);
+                success_latencies.extend(s_lats);
+                failure_latencies.extend(f_lats);
             }
             Err(join_err) => {
                 worker_failures += 1;
@@ -505,27 +528,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    if !all_latencies.is_empty() {
-        println!("\nLatency metrics (ms):");
+    if !success_latencies.is_empty() {
+        success_latencies.sort_by(|a, b| a.total_cmp(b));
+        print_latency_block("Latency (successful requests, ms)", &success_latencies);
+    }
 
-        let mut sorted_latencies = all_latencies;
-        sorted_latencies.sort_by(|a, b| a.total_cmp(b));
-
-        let min = sorted_latencies[0];
-        let max = sorted_latencies[sorted_latencies.len() - 1];
-        let avg = sorted_latencies.iter().sum::<f64>() / sorted_latencies.len() as f64;
-        let p50 = percentile(&sorted_latencies, 50.0);
-        let p90 = percentile(&sorted_latencies, 90.0);
-        let p95 = percentile(&sorted_latencies, 95.0);
-        let p99 = percentile(&sorted_latencies, 99.0);
-
-        println!("  Min:  {:.2}", min);
-        println!("  Max:  {:.2}", max);
-        println!("  Avg:  {:.2}", avg);
-        println!("  p50:  {:.2}", p50);
-        println!("  p90:  {:.2}", p90);
-        println!("  p95:  {:.2}", p95);
-        println!("  p99:  {:.2}", p99);
+    if !failure_latencies.is_empty() {
+        failure_latencies.sort_by(|a, b| a.total_cmp(b));
+        print_latency_block("Latency (failed requests, ms)", &failure_latencies);
     }
 
     if worker_failures > 0 {


### PR DESCRIPTION
Closes - #5 , #6 , #14 , #15 , #16 

## Summary

- **fix(timeout)**: replace hard-coded 5 s request timeout with `--request-timeout-ms` / `--connect-timeout-ms` CLI flags; timeouts reported as a separate metric category in the summary
- **fix(runtime)**: enforce duration deadline for in-flight work via `JoinSet::abort_all()`; new requests stop at deadline and in-flight tasks are hard-cancelled
- **feat(metrics)**: separate success vs failure latency distributions; timed-out requests contribute a capped latency sample to the failure bucket
- **fix(metrics)**: split throughput into `Req/s (in-duration)` and `Req/s (end-to-end)` when a duration limit is hit
- **feat(observability)**: connection attempts/failures, handshake latency percentiles, peak stream concurrency, and `--json` output for offline analysis